### PR TITLE
Fix ssl-check for interactive menus

### DIFF
--- a/src/receiver/middleware/parse-options.js
+++ b/src/receiver/middleware/parse-options.js
@@ -9,13 +9,13 @@ module.exports = () => {
       let body = req.body
 
       if (!body || !body.payload) {
-        return next(new Error('Invalid request: payload missing'))
+        return res.send('Invalid request: payload missing')
       }
 
       try {
         body = JSON.parse(body.payload)
       } catch (e) {
-        return next(new Error('Error parsing payload'))
+        return res.send('Error parsing payload')
       }
 
       req.slapp = {

--- a/test/middleware.parse-options.test.js
+++ b/test/middleware.parse-options.test.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const test = require('ava').test
+const sinon = require('sinon')
 const ParseOptions = require('../src/receiver/middleware/parse-options')
 const fixtures = require('./fixtures/')
 
@@ -9,26 +10,24 @@ test('ParseOptions()', t => {
   t.is(mw.length, 2)
 })
 
-test.cb('ParseOptions() no payload', t => {
+test('ParseOptions() no payload', t => {
   let mw = ParseOptions().pop()
-  let req = { body: {} }
-  let res = fixtures.getMockRes()
 
-  mw(req, res, (err) => {
-    t.truthy(err)
-    t.end()
-  })
+  let res = fixtures.getMockRes()
+  let sendStub = sinon.stub(res, 'send')
+
+  mw({ body: {} }, res, () => t.fail())
+  t.true(sendStub.calledWith('Invalid request: payload missing'))
 })
 
-test.cb('ParseOptions() unparsable payload', t => {
+test('ParseOptions() unparsable payload', t => {
   let mw = ParseOptions().pop()
-  let req = { body: { payload: '"invalid' } }
-  let res = fixtures.getMockRes()
 
-  mw(req, res, (err) => {
-    t.truthy(err)
-    t.end()
-  })
+  let res = fixtures.getMockRes()
+  let sendStub = sinon.stub(res, 'send')
+
+  mw({ body: { payload: '\\{"' } }, res, () => t.fail())
+  t.true(sendStub.calledWith('Error parsing payload'))
 })
 
 test.cb('ParseOptions() with payload', t => {


### PR DESCRIPTION
Slack validates Options Load URL when App Distribution is enabled. And because of the absence of `payload` param in request body slapp throws an error.

![image](https://user-images.githubusercontent.com/4338228/36853913-5765b5cc-1d78-11e8-8710-14f7694e8b59.png)

This PR fixes current behavior to send 200 http code in case payload is missing or invalid in the same way ParseAction middleware works.