### PR TITLE
Small fixes to JS syntax in Getting Started Documentation Example

### DIFF
--- a/docs/_tutorials/getting_started.md
+++ b/docs/_tutorials/getting_started.md
@@ -176,7 +176,7 @@ const app = new App({
 // Listens to incoming messages that contain "hello"
 app.message('hello', ({ message, say }) => {
   // say() sends a message to the channel where the event was triggered
-  say(`Hey there <@{message.user}!`);
+  say(`Hey there ${message.user}!`);
 });
 
 (async () => {
@@ -224,7 +224,7 @@ app.message('hello', ({ message, say }) => {
 		    "type": "section",
         "text": {
           "type": "plain_text",
-          "text": `Hey there <@{message.user}!`
+          "text": `Hey there ${message.user}!`
         },
         "accessory": {
           "type": "button",
@@ -289,8 +289,8 @@ app.message('hello', ({ message, say }) => {
   });
 });
 
-app.action('button_click', ({ action, say }) {
-  say(`@{action.user} clicked the button`);
+app.action('button_click', ({ action, say }) => {
+  say(`${action.user} clicked the button`);
 });
 
 (async () => {


### PR DESCRIPTION
###  Summary

This fixes some minor JS syntax errors in Getting Started Documentation Example

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).