### PR TITLE
Fix block action detection, remove StringIndexed from action body types

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -481,7 +481,7 @@ function buildSource(
 function isBlockActionOrInteractiveMessageBody(
   body: SlackActionMiddlewareArgs['body'],
 ): body is SlackActionMiddlewareArgs<BlockAction | InteractiveMessage>['body'] {
-  return (body as SlackActionMiddlewareArgs<BlockAction | InteractiveMessage>['body']).action !== undefined;
+  return (body as SlackActionMiddlewareArgs<BlockAction | InteractiveMessage>['body']).actions !== undefined;
 }
 
 function defaultErrorHandler(logger: Logger): ErrorHandler {

--- a/src/types/actions/block-action.ts
+++ b/src/types/actions/block-action.ts
@@ -118,7 +118,7 @@ export interface DatepickerAction extends BasicElementAction<'datepicker'> {
  *
  * This describes the entire JSON-encoded body of a request from Slack's Block Kit interactive components.
  */
-export interface BlockAction<ElementAction extends BasicElementAction = BlockElementAction> extends StringIndexed {
+export interface BlockAction<ElementAction extends BasicElementAction = BlockElementAction> {
   type: 'block_actions';
   actions: [ElementAction];
   team: {
@@ -166,9 +166,3 @@ export type BlockChannelsSelectAction = BlockAction<ChannelsSelectAction>;
 export type BlockExternalSelectAction = BlockAction<ExternalSelectAction>;
 export type BlockOverflowAction = BlockAction<OverflowAction>;
 export type BlockDatepickerAction = BlockAction<DatepickerAction>;
-
-// Relics of the past
-
-// type KnownActionFromElementType<T extends string> = Extract<ElementAction, { type: T }>;
-// type ActionFromElementType<T extends string> = KnownActionFromElementType<T> extends never ?
-//   BasicElementAction<T> : KnownActionFromElementType<T>;

--- a/src/types/actions/dialog-action.ts
+++ b/src/types/actions/dialog-action.ts
@@ -1,11 +1,9 @@
-import { StringIndexed } from '../helpers';
-
 /**
  * A Slack dialog submit action wrapped in the standard metadata.
  *
  * This describes the entire JSON-encoded body of a request from Slack dialogs.
  */
-export interface DialogSubmitAction extends StringIndexed {
+export interface DialogSubmitAction {
   type: 'dialog_submission';
   callback_id: string;
   submission: { [name: string]: string };

--- a/src/types/actions/interactive-message.ts
+++ b/src/types/actions/interactive-message.ts
@@ -1,5 +1,3 @@
-import { StringIndexed } from '../helpers';
-
 /**
  * All actions which Slack delivers from legacy interactive messages. The full body of these actions are represented
  * as [[InteractiveMessage]].
@@ -31,7 +29,7 @@ export interface MenuSelect {
  *
  * This describes the entire JSON-encoded body of a request from Slack's legacy interactive messages.
  */
-export interface InteractiveMessage<Action extends InteractiveAction = InteractiveAction> extends StringIndexed {
+export interface InteractiveMessage<Action extends InteractiveAction = InteractiveAction> {
   type: 'interactive_message';
   callback_id: string;
   actions: [Action];

--- a/src/types/actions/message-action.ts
+++ b/src/types/actions/message-action.ts
@@ -1,11 +1,9 @@
-import { StringIndexed } from '../helpers';
-
 /**
  * A Slack message action wrapped in the standard metadata.
  *
  * This describes the entire JSON-encoded body of a request from Slack message actions.
  */
-export interface MessageAction extends StringIndexed {
+export interface MessageAction {
   type: 'message_action';
   callback_id: string;
   trigger_id: string;


### PR DESCRIPTION
###  Summary

The issue is described in [much more detail here](https://github.com/slackapi/bolt/issues/163#issuecomment-486394331). This PR does two things:

1. Removes `StringIndexed` from `SlackAction` (and the interfaces in that union). `SlackAction` represents the body of an action request, and in this case the fact that each of its constituent types also had an index signature (provided by `StringIndexed`) meant that the typechecker allowed unknown property names to evaluate to `any`. This is working against us when we use types to describe how we manipulate or conditionally check these action bodies. **We might want to remove `StringIndexed` from more places in the future**.

2. Changes the `action` property lookup to `actions`. This fixes the issue with detection.

Fixes #163 

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).