### PR TITLE
Add missing ack() for command()

### DIFF
--- a/docs/_advanced/context.md
+++ b/docs/_advanced/context.md
@@ -22,7 +22,9 @@ async function addTimezoneContext ({ payload, context, next }) {
   context.tz_offset = user.tz_offset;
 }
 
-app.command('request', addTimezoneContext, async ({ command, context }) => {
+app.command('request', addTimezoneContext, async ({ command, ack, context }) => {
+  // Acknowledge command request
+  ack();
   // Get local hour of request
   const local_hour = (Date.UTC() + context.tz_offset).getHours();
 

--- a/docs/_basic/listening_responding_commands.md
+++ b/docs/_basic/listening_responding_commands.md
@@ -12,7 +12,10 @@ Similar to actions, there are two ways to respond to slash command requests. The
 
 ```javascript
 // The echo command simply echoes on command
-app.command('/echo', async ({ command, say }) => {
+app.command('/echo', async ({ command, ack, say }) => {
+  // Acknowledge command request
+  ack();
+  
   say(`${command.text}`);
 });
 ```


### PR DESCRIPTION
###  Summary

Didn't add `ack()` for the original docs. This fixes that.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).