### PR TITLE
Bind this for async rejection handling

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -343,7 +343,7 @@ export default class App {
         const postMessageArguments: ChatPostMessageArguments = (typeof message === 'string') ?
           { token, text: message, channel: channelId } : { ...message, token, channel: channelId };
         this.client.chat.postMessage(postMessageArguments)
-          .catch(this.onGlobalError);
+          .catch(error => this.onGlobalError(error));
       };
     };
 


### PR DESCRIPTION
###  Summary

This small patch intends to resolve an `this == undefined` issue from using `onGlobalError` for handling Promise rejection errors. The the `App` instance is lost by only passing the function. The following error can be observed:

```
[DEBUG]  WebClient:0 initialized
[DEBUG]  WebClient:0 apiCall() start
[DEBUG]  WebClient:0 will perform http request
⚡️ Bolt app is running!
[DEBUG]  WebClient:0 http response received
[DEBUG]  WebClient:0 apiCall() start
[DEBUG]  WebClient:0 will perform http request
[DEBUG]  WebClient:0 http response received
[DEBUG]   Conversation context not loaded: Conversation not found
[DEBUG]  WebClient:0 apiCall() start
[DEBUG]  WebClient:0 will perform http request
[DEBUG]  WebClient:0 http response received
(node:20128) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'errorHandler' of undefined
    at onGlobalError (/home/sethlu/gamescrafters-slack-bot/node_modules/@slack/bolt/dist/App.js:231:14)
    at processTicksAndRejections (internal/process/task_queues.js:89:5)
(node:20128) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 2)
(node:20128) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```

And with the following code... Using a slash command in a DM or using the slash command `/test` without any text should raise an error.

```js
const { App, LogLevel } = require('@slack/bolt');

const app = new App({
    signingSecret: process.env.SLACK_SIGNING_SECRET,
    token: process.env.SLACK_BOT_TOKEN,
    logLevel: LogLevel.DEBUG
});

app.command('/test', async ({ command, ack, respond }) => {
    // Acknowledge command request
    ack();

    say(`${command.text}`);
});

(async () => {
    // Start the app
    await app.start(process.env.PORT || 3000);

    console.log('⚡️ Bolt app is running!');
})();
```

A similar solution is consulted from:

https://github.com/slackapi/bolt/blob/d3428aee9715c131c1ef54aa695456e08a0ce8ed/src/App.ts#L175

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).