### PR TITLE
wraps call to this.onGlobalError in function so proper context is avaible

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -343,7 +343,7 @@ export default class App {
         const postMessageArguments: ChatPostMessageArguments = (typeof message === 'string') ?
           { token, text: message, channel: channelId } : { ...message, token, channel: channelId };
         this.client.chat.postMessage(postMessageArguments)
-          .catch(this.onGlobalError);
+          .catch((err) => this.onGlobalError(err));
       };
     };
 


### PR DESCRIPTION
###  Summary

In the `createSay` factory function passes the `onGlobalError` function by reference, but the function isn't bound to `this`. When the `this.errorHandler` is ultimately called, `this` is undefined and the error handler fails. The fix should be just wrapping the call in an arrow function.

Here's the error I get:
```
onGlobalError undefined
(node:55029) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'errorHandler' of undefined
    at onGlobalError (/Users/cfurfarostrode/src/projects/tldr-bot/node_modules/@slack/bolt/dist/App.js:233:14)
    at process._tickCallback (internal/process/next_tick.js:68:7)
```

Here's the line of code affected:
https://github.com/slackapi/bolt/blob/d3428aee9715c131c1ef54aa695456e08a0ce8ed/src/App.ts#L346

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).