### PR TITLE
Fix several spelling errors on docs

### DIFF
--- a/docs/_site/concepts.html
+++ b/docs/_site/concepts.html
@@ -443,7 +443,7 @@
             <h3 id="acknowledge">Acknowledging requests</h3>
 
             <div class="section-content">
-  <p>Actions, commands, and options requests must <strong>always</strong> be acknowledged using the <code class="highlighter-rouge">ack()</code> function. This lets Slack know that the request was received and updates the Slack user interface accordingly. Depending on the type of reuqest, your acknowledgement may be different. For example, when responding to a dialog submission you will call <code class="highlighter-rouge">ack()</code> with validation errors if the submission contains errors, or with no parameters if the submission is valid.</p>
+  <p>Actions, commands, and options requests must <strong>always</strong> be acknowledged using the <code class="highlighter-rouge">ack()</code> function. This lets Slack know that the request was received and updates the Slack user interface accordingly. Depending on the type of request, your acknowledgement may be different. For example, when responding to a dialog submission you will call <code class="highlighter-rouge">ack()</code> with validation errors if the submission contains errors, or with no parameters if the submission is valid.</p>
 
   <p>We recommend calling <code class="highlighter-rouge">ack()</code> right away before sending a new message or fetching information from your database since you only have 3 seconds to respond.</p>
 </div>

--- a/docs/_site/tutorial/getting-started.html
+++ b/docs/_site/tutorial/getting-started.html
@@ -153,7 +153,7 @@
 
 <p>After you fill out an app name (<em>you can change it later</em>) and picking a workspace to install it to, hit the <code class="highlighter-rouge">Create App</code> button and you’ll land on your app’s <strong>Basic Information</strong> page.</p>
 
-<p>This page contains an overview of your app in addition to important credentials you’ll need later, like the <code class="highlighter-rouge">Signing Secret</code> under the <strong>App Crendentials</strong> header.</p>
+<p>This page contains an overview of your app in addition to important credentials you’ll need later, like the <code class="highlighter-rouge">Signing Secret</code> under the <strong>App Credentials</strong> header.</p>
 
 <p><img src="../assets/basic-information-page.png" alt="Basic Information page" title="Basic Information page" /></p>
 
@@ -164,7 +164,7 @@
 <h3 id="tokens-and-installing-apps">Tokens and installing apps</h3>
 <p>Slack apps use the industry standard <a href="https://api.slack.com/docs/oauth">OAuth to manage access to Slack’s APIs</a>. When an app is installed, you’ll receive a token that your app can use to call various API methods.</p>
 
-<p>There are two token types availalbe to a Slack app: user (<code class="highlighter-rouge">xoxp</code>) tokens and bot (<code class="highlighter-rouge">xoxb</code>) tokens. User tokens allow you to call API methods on behalf of users who are a part of your workspace. By default, your app receive an <code class="highlighter-rouge">xoxp</code> token associated with the person who installs the app. Bot tokens require adding a bot user to your app, which is granted a default set of permissions.</p>
+<p>There are two token types available to a Slack app: user (<code class="highlighter-rouge">xoxp</code>) tokens and bot (<code class="highlighter-rouge">xoxb</code>) tokens. User tokens allow you to call API methods on behalf of users who are a part of your workspace. By default, your app receive an <code class="highlighter-rouge">xoxp</code> token associated with the person who installs the app. Bot tokens require adding a bot user to your app, which is granted a default set of permissions.</p>
 
 <p><a href="https://api.slack.com/docs/oauth-scopes">Tokens require one or more scopes</a>, which define the actions the token can perform. Every API method has a corresponding scope that’s required for an app to call the method.</p>
 
@@ -189,7 +189,7 @@
 <h3 id="setting-up-your-local-project">Setting up your local project</h3>
 <p>With the initial configuration handled, it’s time to set up a new Bolt project. This is where you’ll write the code that handles the logic for your app. One important thing to note is that Slack doesn’t host your code — you do.</p>
 
-<p>If you don’t already have a project, let’s create a new one. Create an empty directory and initalize a new project:</p>
+<p>If you don’t already have a project, let’s create a new one. Create an empty directory and initialize a new project:</p>
 
 <div class="language-shell highlighter-rouge">
   <div class="highlight">
@@ -216,7 +216,7 @@ npm init
 </div>
 
 <ol>
-  <li><strong>Copy your bot (xoxb) token from the OAuth &amp; Permissions page</strong> and store it in another enviornment variable.</li>
+  <li><strong>Copy your bot (xoxb) token from the OAuth &amp; Permissions page</strong> and store it in another environment variable.</li>
 </ol>
 
 <div class="language-shell highlighter-rouge">
@@ -241,7 +241,7 @@ npm init
   <div class="highlight">
     <pre class="highlight"><code><span class="kd">const</span> <span class="p">{</span> <span class="nx">App</span> <span class="p">}</span> <span class="o">=</span> <span class="nx">require</span><span class="p">(</span><span class="s1">'@slack/bolt'</span><span class="p">);</span>
 
-<span class="c1">// Initalizes your app with your bot token and signing secret</span>
+<span class="c1">// Initializes your app with your bot token and signing secret</span>
 <span class="kd">const</span> <span class="nx">app</span> <span class="o">=</span> <span class="k">new</span> <span class="nx">App</span><span class="p">({</span>
   <span class="na">token</span><span class="p">:</span> <span class="nx">process</span><span class="p">.</span><span class="nx">env</span><span class="p">.</span><span class="nx">SLACK_BOT_TOKEN</span><span class="p">,</span>
   <span class="na">signingSecret</span><span class="p">:</span> <span class="nx">process</span><span class="p">.</span><span class="nx">env</span><span class="p">.</span><span class="nx">SLACK_SIGNING_SECRET</span>
@@ -286,7 +286,7 @@ npm init
 
   <p>If you’re just getting started with your app’s development, you probably don’t have a publicly accessible URL yet. Eventually, you’ll want to set that up, but for now a development proxy like <a href="https://ngrok.com/">ngrok</a> will do the job. We’ve written a separate tutorial about <a href="https://api.slack.com/tutorials/tunneling-with-ngrok">using ngrok with Slack for local development</a> that should help you get everything set up.</p>
 
-  <p>Once you’ve installed a development proxy, run it to begin forwarding requests to a specific port (we’re using port 3000 for this example, but if you customized the port used to intialize your app use that port instead):</p>
+  <p>Once you’ve installed a development proxy, run it to begin forwarding requests to a specific port (we’re using port 3000 for this example, but if you customized the port used to initialize your app use that port instead):</p>
 
   <div class="language-shell highlighter-rouge">
     <div class="highlight">

--- a/docs/_tutorials/getting_started.md
+++ b/docs/_tutorials/getting_started.md
@@ -32,7 +32,7 @@ First thing's first: before you start developing with Bolt, you'll want to [crea
 
 After you fill out an app name (_you can change it later_) and pick a workspace to install it to, hit the `Create App` button and you'll land on your app's **Basic Information** page.
 
-This page contains an overview of your app in addition to important credentials you'll need later, like the `Signing Secret` under the **App Crendentials** header. 
+This page contains an overview of your app in addition to important credentials you'll need later, like the `Signing Secret` under the **App Credentials** header. 
 
 ![Basic Information page](../assets/basic-information-page.png "Basic Information page")
 
@@ -64,7 +64,7 @@ You'll see two tokens. For now, we'll just use the `xoxb` bot token. (If you scr
 ### Setting up your local project
 With the initial configuration handled, it's time to set up a new Bolt project. This is where you'll write the code that handles the logic for your app.
 
-If you don’t already have a project, let’s create a new one. Create an empty directory and initalize a new project:
+If you don’t already have a project, let’s create a new one. Create an empty directory and initialize a new project:
 
 ```shell
 mkdir first-bolt-app
@@ -82,7 +82,7 @@ Before we install the Bolt package to your new project, let's save the bot token
 export SLACK_SIGNING_SECRET=<your-signing-secret>
 ```
 
-2. **Copy your bot (xoxb) token from the OAuth & Permissions page** and store it in another enviornment variable.
+2. **Copy your bot (xoxb) token from the OAuth & Permissions page** and store it in another environment variable.
 
 ```shell
 export SLACK_BOT_TOKEN=xoxb-<your-bot-token>
@@ -141,7 +141,7 @@ When an event occurs, Slack will send your app some information about the event,
 
 If you’re just getting started with your app's development, you probably don’t have a publicly accessible URL yet. Eventually, you’ll want to set that up, but for now a development proxy like [ngrok](https://ngrok.com/) will create a public URL and tunnel  requests to your own development environment. We've written a separate tutorial about [using ngrok with Slack for local development](https://api.slack.com/tutorials/tunneling-with-ngrok) that should help you get everything set up.
 
-Once you’ve installed a development proxy, run it to begin forwarding requests to a specific port (we’re using port 3000 for this example, but if you customized the port used to intialize your app use that port instead):
+Once you’ve installed a development proxy, run it to begin forwarding requests to a specific port (we’re using port 3000 for this example, but if you customized the port used to initialize your app use that port instead):
 
 ```shell
 ngrok http 3000


### PR DESCRIPTION
###  Summary

This pull request just fixes several spelling errors on docs. I noticed them thanks to my editor's suggestions.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).