### PR TITLE
Fail fast when user's node version doesn't meet minimum requirement

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
     "dist/**/*"
   ],
   "engines": {
-    "node": ">= 10.13.0",
-    "npm": ">= 6.4.1"
+    "node": ">=10.13.0",
+    "npm": ">=6.4.1"
   },
   "scripts": {
     "prepare": "npm run build",
@@ -45,6 +45,7 @@
     "@types/node": ">=10",
     "axios": "^0.18.0",
     "express": "^4.16.4",
+    "please-upgrade-node": "^3.1.1",
     "raw-body": "^2.3.3",
     "tsscmp": "^1.0.6"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,8 @@
+const packageJson = require('../package.json'); // tslint:disable-line:no-require-imports no-var-requires
+import pleaseUpgradeNode from 'please-upgrade-node';
+
+pleaseUpgradeNode(packageJson);
+
 export {
   default as App,
   AppOptions,

--- a/types/please-upgrade-node.d.ts
+++ b/types/please-upgrade-node.d.ts
@@ -1,0 +1,8 @@
+export = pleaseUpgradeNode;
+
+interface Options {
+  message?: (requiredVersion: string) => unknown;
+  exitCode?: number;
+}
+
+declare function pleaseUpgradeNode(packageJson: any, options?: Options): void;


### PR DESCRIPTION
###  Summary

Fixes #174 

I haven't added any tests for this functionality because it would involve intentionally adding unsupported version of node into our test matrix, and then specifying an assertion that none of the tests pass. This would slow things down, and introduce complexity in our test scripts, with very little value to show for it.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).