### PR TITLE
Fix builtin middleware for message events with no text

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "build": "tsc",
     "build:clean": "shx rm -rf ./dist ./coverage ./.nyc_output",
     "lint": "tslint --project .",
-    "test": "nyc mocha --config .mocharc.json src/*.spec.ts",
+    "test": "nyc mocha --config .mocharc.json \"src/**/*.spec.ts\"",
     "coverage": "codecov"
   },
   "repository": "slackapi/bolt",

--- a/src/conversation-store.spec.ts
+++ b/src/conversation-store.spec.ts
@@ -2,7 +2,7 @@
 import 'mocha';
 import { assert, AssertionError } from 'chai';
 import sinon, { SinonSpy } from 'sinon';
-import { Override, createFakeLogger, delay } from './test-helpers';
+import { Override, createFakeLogger, delay, wrapToResolveOnFirstCall } from './test-helpers';
 import rewiremock from 'rewiremock';
 import { ConversationStore } from './conversation-store';
 import { AnyMiddlewareArgs, NextMiddleware, Context } from './types';
@@ -222,41 +222,5 @@ function createFakeStore(
   return {
     set: setSpy as SinonSpy<Parameters<ConversationStore['set']>, ReturnType<ConversationStore['set']>>,
     get: getSpy as SinonSpy<Parameters<ConversationStore['get']>, ReturnType<ConversationStore['get']>>,
-  };
-}
-
-// Utility functions
-function wrapToResolveOnFirstCall<T extends (...args: any[]) => void>(
-  original: T,
-  timeoutMs: number = 1000,
-): { fn: (...args: Parameters<T>) => Promise<void>; promise: Promise<void>; } {
-  // tslint:disable-next-line:no-empty
-  let firstCallResolve: (value?: void | PromiseLike<void>) => void = () => { };
-  let firstCallReject: (reason?: any) => void = () => { }; // tslint:disable-line:no-empty
-
-  const firstCallPromise: Promise<void> = new Promise((resolve, reject) => {
-    firstCallResolve = resolve;
-    firstCallReject = reject;
-  });
-
-  const wrapped = async function (this: ThisParameterType<T>, ...args: Parameters<T>): Promise<void> {
-    try {
-      await original.call(this, ...args);
-      firstCallResolve();
-    } catch (error) {
-      firstCallReject(error);
-    }
-  };
-
-  setTimeout(
-    () => {
-      firstCallReject(new Error('First call to function took longer than expected'));
-    },
-    timeoutMs,
-  );
-
-  return {
-    promise: firstCallPromise,
-    fn: wrapped,
   };
 }

--- a/src/middleware/builtin.spec.ts
+++ b/src/middleware/builtin.spec.ts
@@ -1,0 +1,228 @@
+// tslint:disable:no-implicit-dependencies
+import 'mocha';
+import { assert } from 'chai';
+import sinon from 'sinon';
+import { Override, delay, wrapToResolveOnFirstCall } from '../test-helpers';
+import rewiremock from 'rewiremock';
+import { SlackEventMiddlewareArgs, NextMiddleware, Context, MessageEvent } from '../types';
+
+describe('matchMessage()', () => {
+  it('should initialize with a string', async () => {
+    // Arrange
+    const { matchMessage } = await importBuiltin();
+
+    // Act
+    const middleware = matchMessage('string pattern');
+
+    // Assert
+    assert.isOk(middleware);
+  });
+
+  it('should initialize with a RegExp', async () => {
+    // Arrange
+    const { matchMessage } = await importBuiltin();
+
+    // Act
+    const middleware = matchMessage(/a RegExp pattern/);
+
+    // Assert
+    assert.isOk(middleware);
+  });
+
+  it('should match message events in which the text matches the string pattern', async () => {
+    // Arrange
+    const dummyPattern = 'foo';
+    const dummyMatchingMessageEvent: MessageEvent = {
+      text: 'foobar',
+      type: 'message',
+      channel: 'CHANNEL_ID',
+      user: 'USER_ID',
+      ts: 'MESSAGE_ID',
+    };
+    const dummyContext: DummyContext = {};
+    const { fn: next, promise: onNextFirstCall } = wrapToResolveOnFirstCall(assertions);
+    const fakeArgs = {
+      next,
+      message: dummyMatchingMessageEvent,
+      context: dummyContext,
+    } as unknown as MessageMiddlewareArgs;
+    const { matchMessage } = await importBuiltin();
+
+    // Act
+    const middleware = matchMessage(dummyPattern);
+    middleware(fakeArgs);
+    await delay();
+
+    // Assert
+    async function assertions(...args: any[]): Promise<void> {
+      assert.notExists(args[0]);
+    }
+    return onNextFirstCall;
+  });
+
+  it('should match message events in which the text matches the RegExp pattern', async () => {
+    // Arrange
+    const dummyPattern = /foo/;
+    const dummyMatchingMessageEvent: MessageEvent = {
+      text: 'foobar',
+      type: 'message',
+      channel: 'CHANNEL_ID',
+      user: 'USER_ID',
+      ts: 'MESSAGE_ID',
+    };
+    const dummyContext: DummyContext = {};
+    const { fn: next, promise: onNextFirstCall } = wrapToResolveOnFirstCall(assertions);
+    const fakeArgs = {
+      next,
+      message: dummyMatchingMessageEvent,
+      context: dummyContext,
+    } as unknown as MessageMiddlewareArgs;
+    const { matchMessage } = await importBuiltin();
+
+    // Act
+    const middleware = matchMessage(dummyPattern);
+    middleware(fakeArgs);
+    await delay();
+
+    // Assert
+    async function assertions(...args: any[]): Promise<void> {
+      assert.notExists(args[0]);
+      if (dummyContext.matches !== undefined) {
+        assert.lengthOf(dummyContext.matches, 1);
+      } else {
+        assert.fail();
+      }
+    }
+    return onNextFirstCall;
+  });
+
+  it('should filter out message events which do not match a string pattern', async () => {
+    // Arrange
+    const dummyPattern = 'foo';
+    const dummyMismatchingMessageEvent: MessageEvent = {
+      text: 'bar',
+      type: 'message',
+      channel: 'CHANNEL_ID',
+      user: 'USER_ID',
+      ts: 'MESSAGE_ID',
+    };
+    const dummyContext = {};
+    const fakeNext = sinon.fake();
+    const fakeArgs = {
+      message: dummyMismatchingMessageEvent,
+      context: dummyContext,
+      next: fakeNext,
+    } as unknown as MessageMiddlewareArgs;
+    const { matchMessage } = await importBuiltin();
+
+    // Act
+    const middleware = matchMessage(dummyPattern);
+    middleware(fakeArgs);
+    await delay();
+
+    // Assert
+    assert(fakeNext.notCalled);
+    assert.notProperty(dummyContext, 'matches');
+  });
+
+  it('should filter out message events which do not match a RegExp pattern', async () => {
+    // Arrange
+    const dummyPattern = /foo/;
+    const dummyMismatchingMessageEvent: MessageEvent = {
+      text: 'bar',
+      type: 'message',
+      channel: 'CHANNEL_ID',
+      user: 'USER_ID',
+      ts: 'MESSAGE_ID',
+    };
+    const dummyContext = {};
+    const fakeNext = sinon.fake();
+    const fakeArgs = {
+      message: dummyMismatchingMessageEvent,
+      context: dummyContext,
+      next: fakeNext,
+    } as unknown as MessageMiddlewareArgs;
+    const { matchMessage } = await importBuiltin();
+
+    // Act
+    const middleware = matchMessage(dummyPattern);
+    middleware(fakeArgs);
+    await delay();
+
+    // Assert
+    assert(fakeNext.notCalled);
+    assert.notProperty(dummyContext, 'matches');
+  });
+
+  it('should filter out message events which do not have text (block kit messages) with a string pattern', async () => {
+    // Arrange
+    const dummyPattern = 'foo';
+    const dummyMismatchingMessageEvent: MessageEvent = {
+      type: 'message',
+      blocks: [{ type: 'divider' }],
+      channel: 'CHANNEL_ID',
+      user: 'USER_ID',
+      ts: 'MESSAGE_ID',
+    };
+    const dummyContext = {};
+    const fakeNext = sinon.fake();
+    const fakeArgs = {
+      message: dummyMismatchingMessageEvent,
+      context: dummyContext,
+      next: fakeNext,
+    } as unknown as MessageMiddlewareArgs;
+    const { matchMessage } = await importBuiltin();
+
+    // Act
+    const middleware = matchMessage(dummyPattern);
+    middleware(fakeArgs);
+    await delay();
+
+    // Assert
+    assert(fakeNext.notCalled);
+    assert.notProperty(dummyContext, 'matches');
+  });
+
+  it('should filter out message events which do not have text (block kit messages) with a RegExp pattern', async () => {
+    // Arrange
+    const dummyPattern = /foo/;
+    const dummyMismatchingMessageEvent: MessageEvent = {
+      type: 'message',
+      blocks: [{ type: 'divider' }],
+      channel: 'CHANNEL_ID',
+      user: 'USER_ID',
+      ts: 'MESSAGE_ID',
+    };
+    const dummyContext = {};
+    const fakeNext = sinon.fake();
+    const fakeArgs = {
+      message: dummyMismatchingMessageEvent,
+      context: dummyContext,
+      next: fakeNext,
+    } as unknown as MessageMiddlewareArgs;
+    const { matchMessage } = await importBuiltin();
+
+    // Act
+    const middleware = matchMessage(dummyPattern);
+    middleware(fakeArgs);
+    await delay();
+
+    // Assert
+    assert(fakeNext.notCalled);
+    assert.notProperty(dummyContext, 'matches');
+  });
+});
+
+/* Testing Harness */
+
+interface DummyContext {
+  matches?: RegExpExecArray;
+}
+
+type MessageMiddlewareArgs = SlackEventMiddlewareArgs<'message'> & { next: NextMiddleware, context: Context };
+
+async function importBuiltin(
+  overrides: Override = {},
+): Promise<typeof import('./builtin')> {
+  return rewiremock.module(() => import('./builtin'), overrides);
+}

--- a/src/middleware/builtin.ts
+++ b/src/middleware/builtin.ts
@@ -262,6 +262,10 @@ export function directMention(): Middleware<SlackEventMiddlewareArgs<'message'>>
       return;
     }
 
+    if (message.text === undefined) {
+      return;
+    }
+
     // Match the message text with a user mention format
     const text = message.text.trim();
 

--- a/src/middleware/builtin.ts
+++ b/src/middleware/builtin.ts
@@ -151,9 +151,13 @@ export function matchMessage(pattern: string | RegExp): Middleware<SlackEventMid
   return ({ message, context, next }) => {
     let tempMatches: RegExpMatchArray | null;
 
+    if (message.text === undefined) {
+      return;
+    }
+
     // Filter out messages that don't contain the pattern
     if (typeof pattern === 'string') {
-      if (message.text !== undefined && !message.text.includes(pattern)) {
+      if (!message.text.includes(pattern)) {
         return;
       }
     } else {

--- a/src/types/events/base-events.ts
+++ b/src/types/events/base-events.ts
@@ -385,7 +385,7 @@ export interface MessageEvent extends StringIndexed {
   type: 'message';
   channel: string;
   user: string;
-  text: string;
+  text?: string;
   ts: string;
   attachments?: MessageAttachment[];
   blocks?: (KnownBlock | Block)[];


### PR DESCRIPTION
###  Summary

As outlined in #182, Slack will send apps `message` events without a `text` property when the message was composed with Block Kit. In that situation, Bolt was failing to process the events because it assumed the `text` property contained a string. This change addresses that problem.

Fixes #182 

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).