### PR TITLE
Allow Bolt users to give Context types to listeners

### DIFF
--- a/src/conversation-store.ts
+++ b/src/conversation-store.ts
@@ -1,6 +1,7 @@
 import { Middleware, AnyMiddlewareArgs } from './types';
 import { Logger } from '@slack/logger';
 import { getTypeAndConversation } from './helpers';
+import { Context } from './types/middleware';
 
 /**
  * Storage backend used by the conversation context middleware
@@ -41,6 +42,11 @@ export class MemoryStore<ConversationState = any> implements ConversationStore<C
   }
 }
 
+interface ConversationContext extends Context {
+  updateConversation?: (s: any) => Promise<unknown>;
+  conversation?: any;
+}
+
 /**
  * Conversation context global middleware.
  *
@@ -54,7 +60,7 @@ export class MemoryStore<ConversationState = any> implements ConversationStore<C
 export function conversationContext<ConversationState = any>(
   store: ConversationStore<ConversationState>,
   logger: Logger,
-): Middleware<AnyMiddlewareArgs> {
+): Middleware<AnyMiddlewareArgs, ConversationContext> {
   return (args) => {
     const { body, context, next } = args;
     const { conversationId } = getTypeAndConversation(body as any);

--- a/src/middleware/process.ts
+++ b/src/middleware/process.ts
@@ -10,7 +10,7 @@ import {
 // be dealt with by the global error handler
 export function processMiddleware(
   initialArguments: AnyMiddlewareArgs,
-  middleware: Middleware<AnyMiddlewareArgs>[],
+  middleware: Middleware<AnyMiddlewareArgs, Context>[],
   afterMiddleware: (context: Context, args: AnyMiddlewareArgs, startBubble: (error?: Error) => void) => void,
   afterPostProcess: (error?: Error) => void,
   context: Context = {},

--- a/src/types/middleware.ts
+++ b/src/types/middleware.ts
@@ -15,6 +15,11 @@ export interface PostProcessFn {
 }
 
 export interface Context extends StringIndexed {
+  // See also AuthorizeResult in src/App.ts
+  botToken?: string;
+  userToken?: string;
+  botId?: string;
+  botUserId?: string;
 }
 
 // NOTE: Args should extend AnyMiddlewareArgs, but because of contravariance for function types, including that as a

--- a/src/types/middleware.ts
+++ b/src/types/middleware.ts
@@ -14,19 +14,16 @@ export interface PostProcessFn {
   (error: Error | undefined, done: (error?: Error) => void): unknown;
 }
 
-export interface Context extends StringIndexed {
-  // See also AuthorizeResult in src/App.ts
-  botToken?: string;
-  userToken?: string;
-  botId?: string;
-  botUserId?: string;
+export interface Context {
+}
+export interface StringIndexedContext extends Context, StringIndexed {
 }
 
 // NOTE: Args should extend AnyMiddlewareArgs, but because of contravariance for function types, including that as a
 // constraint would mess up the interface of App#event(), App#message(), etc.
-export interface Middleware<Args> {
+export interface Middleware<Args, CurrentContext extends Context = StringIndexedContext> {
   // TODO: is there something nice we can do to get context's property types to flow from one middleware to the next?
-  (args: Args & { next: NextMiddleware, context: Context }): unknown;
+  (args: Args & { next: NextMiddleware, context: CurrentContext }): unknown;
 }
 
 export interface NextMiddleware {


### PR DESCRIPTION
###  Summary

This pull request adds the property names coming from `AuthorizeResult` to `Context` interface. https://github.com/slackapi/bolt/blob/%40slack/bolt%401.2.0/src/App.ts#L337

When using Bolt in TypeScript, it's a bit inconvenient that we cannot take advantage of auto-completion on editors such as VS Code.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).