### PR TITLE
Fixes axios vulnerability with versions < 0.18.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@slack/web-api": "^5.0.0",
     "@types/express": "^4.16.1",
     "@types/node": ">=10",
-    "axios": "^0.18.0",
+    "axios": "^0.18.1",
     "express": "^4.16.4",
     "please-upgrade-node": "^3.1.1",
     "raw-body": "^2.3.3",


### PR DESCRIPTION
###  Summary

`npm` told me about this when I ran `npm install`.

https://snyk.io/vuln/SNYK-JS-AXIOS-174505

### Requirements (place an `x` in each `[ ]`)

* [X] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [X] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).