### PR TITLE
adds app_requested Events API event

### DIFF
--- a/src/types/events/base-events.ts
+++ b/src/types/events/base-events.ts
@@ -7,6 +7,7 @@ import { MessageAttachment, KnownBlock, Block } from '@slack/types';
  * This is a discriminated union. The discriminant is the `type` property.
  */
 export type SlackEvent =
+  | AppRequestedEvent
   | AppHomeOpenedEvent
   | AppMentionEvent
   | AppUninstalledEvent
@@ -78,6 +79,52 @@ export interface BasicSlackEvent<Type extends string = string> extends StringInd
 
 // TODO: why are these all StringIndexed? who does that really help when going more than one level deep means you have
 // to start coercing types anyway?
+
+export interface AppRequestedEvent extends StringIndexed {
+  type: 'app_requested';
+  app_request: {
+    id: string;
+    app: {
+      id: string;
+      name: string;
+      description: string;
+      help_url: string;
+      privacy_policy_url: string;
+      app_homepage_url: string;
+      app_directory_url: string;
+      is_app_directory_approved: boolean;
+      is_internal: boolean;
+      additional_info: string;
+    };
+  };
+  previous_resolution: {
+    status: 'approved' | 'restricted';
+    scopes: {
+      name: string;
+      description: string;
+      is_dangerous: boolean;
+      token_type: 'bot' | 'user' | 'app' | null;
+    };
+  } | null;
+  user: {
+    id: string;
+    name: string;
+    email: string;
+  };
+  team: {
+    id: string;
+    name: string;
+    domain: string;
+  };
+  scopes: {
+    name: string;
+    description: string;
+    is_dangerous: boolean;
+    token_type: 'bot' | 'user' | 'app' | null;
+  };
+  message: string;
+  date_created: number;
+}
 
 export interface AppHomeOpenedEvent extends StringIndexed {
   type: 'app_home_opened';


### PR DESCRIPTION
###  Summary

Adds the `app_requested` event from the Events API. Learn more: https://api.slack.com/admins/managing#listen_with_the_app_requested_event

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).