### PR TITLE
Allow passing of Slack API URL to App Constructor

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -126,6 +126,7 @@ export default class App {
     authorize = undefined,
     logger = new ConsoleLogger(),
     logLevel = LogLevel.INFO,
+    slackApiUrl = 'https://slack.com/api/',
     ignoreSelf = true,
   }: AppOptions = {}) {
 
@@ -134,7 +135,7 @@ export default class App {
     this.errorHandler = defaultErrorHandler(this.logger);
 
     // TODO: other webclient options (such as proxy)
-    this.client = new WebClient(undefined, { logLevel });
+    this.client = new WebClient(undefined, { logLevel, slackApiUrl });
 
     if (token !== undefined) {
       if (authorize !== undefined) {

--- a/src/App.ts
+++ b/src/App.ts
@@ -49,6 +49,7 @@ export interface AppOptions {
   receiver?: Receiver;
   logger?: Logger;
   logLevel?: LogLevel;
+  slackApiUrl?: string;
   ignoreSelf?: boolean;
 }
 


### PR DESCRIPTION
###  Summary

If in testing phase and targeting an alternate Slack API URL, there is no way to pass this in

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).