### PR TITLE
Add types for channel shared events

### DIFF
--- a/src/types/events/base-events.ts
+++ b/src/types/events/base-events.ts
@@ -17,7 +17,9 @@ export type SlackEvent =
   | ChannelHistoryChangedEvent
   | ChannelLeftEvent
   | ChannelRenameEvent
+  | ChannelSharedEvent
   | ChannelUnarchiveEvent
+  | ChannelUnsharedEvent
   | DNDUpdatedEvent
   | DNDUpdatedUserEvent
   | EmailDomainChangedEvent
@@ -196,10 +198,25 @@ export interface ChannelRenameEvent extends StringIndexed {
   };
 }
 
+export interface ChannelSharedEvent extends StringIndexed {
+  type: 'channel_shared';
+  connected_team_id: string;
+  channel: string;
+  event_ts: string;
+}
+
 export interface ChannelUnarchiveEvent extends StringIndexed {
   type: 'channel_unarchive';
   channel: string;
   user: string;
+}
+
+export interface ChannelUnsharedEvent extends StringIndexed {
+  type: 'channel_unshared';
+  previously_connected_team_id: string;
+  channel: string;
+  is_ext_shared: boolean;
+  event_ts: string;
 }
 
 export interface DNDUpdatedEvent extends StringIndexed {


### PR DESCRIPTION
###  Summary

This pull request adds type declarations for the `channel_shared` and `channel_unshared` events.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).