### PR TITLE
Adds some WebClient options

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -145,6 +145,7 @@ export default class App {
     this.client = new WebClient(undefined, {
       agent,
       logLevel,
+      logger,
       tls: clientTls,
       slackApiUrl: clientOptions !== undefined ? clientOptions.slackApiUrl : undefined,
     });

--- a/src/App.ts
+++ b/src/App.ts
@@ -44,6 +44,8 @@ const packageJson = require('../package.json'); // tslint:disable-line:no-requir
 export interface AppOptions {
   signingSecret?: ExpressReceiverOptions['signingSecret'];
   endpoints?: ExpressReceiverOptions['endpoints'];
+  agent?: ExpressReceiverOptions['agent']; // also WebClientOptions['agent']
+  clientTls?: ExpressReceiverOptions['clientTls']; // also WebClientOptions['tls']
   convoStore?: ConversationStore | false;
   token?: AuthorizeResult['botToken']; // either token or authorize
   botId?: AuthorizeResult['botId']; // only used when authorize is not defined, shortcut for fetching
@@ -53,7 +55,7 @@ export interface AppOptions {
   logger?: Logger;
   logLevel?: LogLevel;
   ignoreSelf?: boolean;
-  clientOptions?: WebClientOptions;
+  clientOptions?: Pick<WebClientOptions, 'slackApiUrl'>;
 }
 
 export { LogLevel, Logger } from '@slack/logger';
@@ -122,6 +124,8 @@ export default class App {
   constructor({
     signingSecret = undefined,
     endpoints = undefined,
+    agent = undefined,
+    clientTls = undefined,
     receiver = undefined,
     convoStore = undefined,
     token = undefined,
@@ -138,11 +142,12 @@ export default class App {
     this.logger.setLevel(logLevel);
     this.errorHandler = defaultErrorHandler(this.logger);
 
-    let options = { logLevel };
-    if (clientOptions !== undefined) {
-      options = { ...clientOptions, ...options };
-    }
-    this.client = new WebClient(undefined, options);
+    this.client = new WebClient(undefined, {
+      agent,
+      logLevel,
+      tls: clientTls,
+      slackApiUrl: clientOptions !== undefined ? clientOptions.slackApiUrl : undefined,
+    });
 
     if (token !== undefined) {
       if (authorize !== undefined) {
@@ -177,7 +182,7 @@ export default class App {
         );
       } else {
         // Create default ExpressReceiver
-        this.receiver = new ExpressReceiver({ signingSecret, logger, endpoints });
+        this.receiver = new ExpressReceiver({ signingSecret, logger, endpoints, agent, clientTls });
       }
     }
 

--- a/src/ExpressReceiver.ts
+++ b/src/ExpressReceiver.ts
@@ -1,8 +1,9 @@
 import { EventEmitter } from 'events';
 import { Receiver, ReceiverEvent, ReceiverAckTimeoutError } from './types';
-import { createServer, Server } from 'http';
+import { createServer, Server, Agent } from 'http';
+import { SecureContextOptions } from 'tls';
 import express, { Request, Response, Application, RequestHandler, NextFunction } from 'express';
-import axios from 'axios';
+import axios, { AxiosInstance } from 'axios';
 import rawBody from 'raw-body';
 import querystring from 'querystring';
 import crypto from 'crypto';
@@ -18,6 +19,8 @@ export interface ExpressReceiverOptions {
   endpoints?: string | {
     [endpointType: string]: string;
   };
+  agent?: Agent;
+  clientTls?: Pick<SecureContextOptions, 'pfx' | 'key' | 'passphrase' | 'cert' | 'ca'>;
 }
 
 /**
@@ -30,10 +33,14 @@ export default class ExpressReceiver extends EventEmitter implements Receiver {
 
   private server: Server;
 
+  private axios: AxiosInstance;
+
   constructor({
     signingSecret = '',
     logger = new ConsoleLogger(),
-    endpoints = { events: '/slack/events' }
+    endpoints = { events: '/slack/events' },
+    agent = undefined,
+    clientTls = undefined,
   }: ExpressReceiverOptions) {
     super();
 
@@ -41,6 +48,13 @@ export default class ExpressReceiver extends EventEmitter implements Receiver {
     this.app.use(this.errorHandler.bind(this));
     // TODO: what about starting an https server instead of http? what about other options to create the server?
     this.server = createServer(this.app);
+    this.axios = axios.create(Object.assign(
+      {
+        httpAgent: agent,
+        httpsAgent: agent,
+      },
+      clientTls,
+    ));
 
     const expressMiddleware: RequestHandler[] = [
       verifySignatureAndParseBody(logger, signingSecret),
@@ -87,7 +101,7 @@ export default class ExpressReceiver extends EventEmitter implements Receiver {
 
     if (req.body && req.body.response_url) {
       event.respond = (response): void => {
-        axios.post(req.body.response_url, response)
+        this.axios.post(req.body.response_url, response)
           .catch((e) => {
             this.emit('error', e);
           });


### PR DESCRIPTION
###  Summary

This PR adds the following options to the `App` constructor:

* `agent`: Allows users to set a custom HTTP agent, which is most often used for setting up proxy support. Will affect both the client HTTP requests made from the `WebClient` and the `ExpressReceiver` (if the default receiver is used).

* `clientTls`: Allows users to set a custom TLS configuration for HTTP client requests. This is most often used to send requests to a specific Slack environment (internal usage). Will affect both the client HTTP requests made from the `WebClient` and the `ExpressReceiver` (if the default receiver is used).

* `clientOptions.slackApiUrl`: Allows users to set a custom endpoint for the Slack API. This is most often used for testing as well as sending requests to a specific Slack environment (internal usage). This only affects the `WebClient`.

It also changes the behavior of the `logger` option to also affect the `WebClient`.

Fixes #221 

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).