### PR TITLE
Add correct logger

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "url": "https://github.com/slackapi/bolt/issues"
   },
   "dependencies": {
-    "@slack/logger": "^1.0.0",
+    "@slack/logger": ">=1.0.0 <3.0.0",
     "@slack/types": "^1.0.0",
     "@slack/web-api": "^5.0.0",
     "@types/express": "^4.16.1",

--- a/src/ExpressReceiver.spec.ts
+++ b/src/ExpressReceiver.spec.ts
@@ -15,6 +15,7 @@ describe('ExpressReceiver', () => {
     warn(..._msg: any[]): void { },
     error(..._msg: any[]): void { },
     setLevel(_level: LogLevel): void { },
+    getLevel(): LogLevel { },
     setName(_name: string): void { },
   };
 

--- a/src/ExpressReceiver.spec.ts
+++ b/src/ExpressReceiver.spec.ts
@@ -15,7 +15,7 @@ describe('ExpressReceiver', () => {
     warn(..._msg: any[]): void { },
     error(..._msg: any[]): void { },
     setLevel(_level: LogLevel): void { },
-    getLevel(): LogLevel { },
+    getLevel(): LogLevel { return LogLevel.DEBUG; },
     setName(_name: string): void { },
   };
 

--- a/src/test-helpers.ts
+++ b/src/test-helpers.ts
@@ -34,6 +34,7 @@ function mergeObjProperties(first: Override, second: Override): Override {
 
 export interface FakeLogger extends Logger {
   setLevel: SinonSpy<Parameters<Logger['setLevel']>, ReturnType<Logger['setLevel']>>;
+  getLevel: SinonSpy<Parameters<Logger['getLevel']>, ReturnType<Logger['getLevel']>>;
   setName: SinonSpy<Parameters<Logger['setName']>, ReturnType<Logger['setName']>>;
   debug: SinonSpy<Parameters<Logger['debug']>, ReturnType<Logger['debug']>>;
   info: SinonSpy<Parameters<Logger['info']>, ReturnType<Logger['info']>>;
@@ -46,6 +47,7 @@ export function createFakeLogger(): FakeLogger {
     // NOTE: the two casts are because of a TypeScript inconsistency with tuple types and any[]. all tuple types
     // should be assignable to any[], but TypeScript doesn't think so.
     setLevel: sinon.fake() as SinonSpy<Parameters<Logger['setLevel']>, ReturnType<Logger['setLevel']>>,
+    getLevel: sinon.fake() as SinonSpy<Parameters<Logger['getLevel']>, ReturnType<Logger['getLevel']>>,
     setName: sinon.fake() as SinonSpy<Parameters<Logger['setName']>, ReturnType<Logger['setName']>>,
     debug: sinon.fake(),
     info: sinon.fake(),


### PR DESCRIPTION
###  Summary

`getLevel()` is now supported so there's minor updates for Bolt to work + run

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).