### PR TITLE
In "opening modals" code example, ove 'type' to be nested inside 'view'

### DIFF
--- a/docs/_basic/ja_opening_modals.md
+++ b/docs/_basic/ja_opening_modals.md
@@ -23,11 +23,11 @@ app.command('/ticket', ({ ack, payload, context }) => {
   try {
     const result = app.client.views.open({
       token: context.botToken,
-      type: 'modal',
       // 適切な trigger_id を受け取ってから 3 秒以内に渡す
       trigger_id: payload.trigger_id,
       // view の値をペイロードに含む
       view: {
+        type: 'modal',
         // callback_id が view を特定するための識別子
         callback_id: 'view_1',
         title: {

--- a/docs/_basic/opening_modals.md
+++ b/docs/_basic/opening_modals.md
@@ -22,11 +22,11 @@ app.command('/ticket', ({ ack, payload, context }) => {
   try {
     const result = app.client.views.open({
       token: context.botToken,
-      type: 'modal',
       // Pass a valid trigger_id within 3 seconds of receiving it
       trigger_id: payload.trigger_id,
       // View payload
       view: {
+        type: 'modal',
         // View identifier
         callback_id: 'view_1',
         title: {


### PR DESCRIPTION
###  Summary

To fix the issue described in #288:

> It looks like the example on https://slack.dev/bolt/concepts#creating-modals has type at the top level object but it should actually be nested in view as shown in https://api.slack.com/reference/block-kit/views



### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).