### PR TITLE
Add tab, view to AppHomeOpenedEvent

### DIFF
--- a/src/types/events/base-events.ts
+++ b/src/types/events/base-events.ts
@@ -1,5 +1,5 @@
 import { StringIndexed } from '../helpers';
-import { MessageAttachment, KnownBlock, Block } from '@slack/types';
+import { MessageAttachment, KnownBlock, Block, View } from '@slack/types';
 
 /**
  * All known event types in Slack's Events API
@@ -132,6 +132,8 @@ export interface AppHomeOpenedEvent extends StringIndexed {
   type: 'app_home_opened';
   user: string;
   channel: string;
+  tab?: 'home' | 'messages';
+  view?: View;
   event_ts: string;
 }
 


### PR DESCRIPTION
###  Summary

Although the API documentation team is still working on the updates on [the page](https://api.slack.com/events/app_home_opened) (the updates will come very soon), `app_home_opened` event has two more fields - `tab` and `view` as announced at the Spec conference yesterday (Refer to https://api.slack.com/surfaces/tabs for details of App Home).

This pull request adds those to the type definition to better support it in TypeScript.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).