### PR TITLE
Fix build failures on TravisCI

### DIFF
--- a/src/conversation-store.spec.ts
+++ b/src/conversation-store.spec.ts
@@ -220,7 +220,14 @@ function createFakeStore(
   setSpy: SinonSpy = sinon.fake.resolves({}),
 ): FakeStore {
   return {
-    set: setSpy as SinonSpy<Parameters<ConversationStore['set']>, ReturnType<ConversationStore['set']>>,
-    get: getSpy as SinonSpy<Parameters<ConversationStore['get']>, ReturnType<ConversationStore['get']>>,
+    // NOTE (Nov 2019): We had to convert to 'unknown' first due to the following error:
+    // src/conversation-store.spec.ts:223:10 - error TS2352: Conversion of type 'SinonSpy<any[], any>' to type 'SinonSpy<[string, any, (number | undefined)?], Promise<unknown>>' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
+    //   Types of property 'firstCall' are incompatible.
+    //     Type 'SinonSpyCall<any[], any>' is not comparable to type 'SinonSpyCall<[string, any, (number | undefined)?], Promise<unknown>>'.
+    //       Type 'any[]' is not comparable to type '[string, any, (number | undefined)?]'.
+    // 223     set: setSpy as SinonSpy<Parameters<ConversationStore['set']>, ReturnType<ConversationStore['set']>>,
+    //              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    set: setSpy as unknown as SinonSpy<Parameters<ConversationStore['set']>, ReturnType<ConversationStore['set']>>,
+    get: getSpy as unknown as SinonSpy<Parameters<ConversationStore['get']>, ReturnType<ConversationStore['get']>>,
   };
 }

--- a/src/test-helpers.ts
+++ b/src/test-helpers.ts
@@ -46,9 +46,14 @@ export function createFakeLogger(): FakeLogger {
   return {
     // NOTE: the two casts are because of a TypeScript inconsistency with tuple types and any[]. all tuple types
     // should be assignable to any[], but TypeScript doesn't think so.
-    setLevel: sinon.fake() as SinonSpy<Parameters<Logger['setLevel']>, ReturnType<Logger['setLevel']>>,
-    getLevel: sinon.fake() as SinonSpy<Parameters<Logger['getLevel']>, ReturnType<Logger['getLevel']>>,
-    setName: sinon.fake() as SinonSpy<Parameters<Logger['setName']>, ReturnType<Logger['setName']>>,
+    // UPDATE (Nov 2019):
+    // src/test-helpers.ts:49:15 - error TS2352: Conversion of type 'SinonSpy<any[], any>' to type 'SinonSpy<[LogLevel], void>' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
+    //   Property '0' is missing in type 'any[]' but required in type '[LogLevel]'.
+    // 49     setLevel: sinon.fake() as SinonSpy<Parameters<Logger['setLevel']>, ReturnType<Logger['setLevel']>>,
+    //                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    setLevel: sinon.fake() as unknown as SinonSpy<Parameters<Logger['setLevel']>, ReturnType<Logger['setLevel']>>,
+    getLevel: sinon.fake() as unknown as SinonSpy<Parameters<Logger['getLevel']>, ReturnType<Logger['getLevel']>>,
+    setName: sinon.fake() as unknown as SinonSpy<Parameters<Logger['setName']>, ReturnType<Logger['setName']>>,
     debug: sinon.fake(),
     info: sinon.fake(),
     warn: sinon.fake(),


### PR DESCRIPTION
###  Summary

The latest builds of this repository have been failing. The situation can be reproduced on your local machine by `rm -rf .nyc_output/ && npm test`.

This pull request fixes the issue by following the suggestion `If this was intentional, convert the expression to 'unknown' first.` in the error message.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).