### PR TITLE
Bump the oldest supported version of node-slack-sdk to support modals for sure (cherry-picking #287)

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,8 +39,8 @@
   },
   "dependencies": {
     "@slack/logger": ">=1.0.0 <3.0.0",
-    "@slack/types": "^1.0.0",
-    "@slack/web-api": "^5.0.0",
+    "@slack/types": "^1.2.1",
+    "@slack/web-api": "^5.2.1",
     "@types/express": "^4.16.1",
     "@types/node": ">=10",
     "axios": "^0.18.1",


### PR DESCRIPTION
###  Summary

With `@slack/web-api` 5.0.0, Block Kit in modals doesn't work in Bot apps as necessary ones are not available in such old versions. https://github.com/slackapi/bolt/issues/306#issuecomment-552709945 is an issue caused by that.

Block Kit in modals are available in `@slack/web-api` 5.2.1.

* https://github.com/slackapi/node-slack-sdk/releases/tag/%40slack%2Fweb-api%405.2.0
* https://github.com/slackapi/node-slack-sdk/releases/tag/%40slack%2Fweb-api%405.2.1

This pull request cherry-picked only the change resolving it from @PerStirpes 's PR #287 .

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).