### PR TITLE
adding type as a valid constraint for app actions

### DIFF
--- a/src/App.spec.ts
+++ b/src/App.spec.ts
@@ -379,6 +379,17 @@ describe('App', () => {
             },
             { // IncomingEventType.Action (app.action)
               body: {
+                type: 'message_action',
+                callback_id: 'another_message_action_callback_id',
+                channel: {},
+                user: {},
+                team: {},
+              },
+              respond: noop,
+              ack: noop,
+            },
+            { // IncomingEventType.Action (app.action)
+              body: {
                 type: 'interactive_message',
                 callback_id: 'interactive_message_callback_id',
                 actions: [{}],
@@ -468,6 +479,8 @@ describe('App', () => {
           app.use((_args) => { ackFn(); });
           app.action('block_action_id', ({ }) => { actionFn(); });
           app.action({ callback_id: 'message_action_callback_id' }, ({ }) => { actionFn(); });
+          app.action({ type: 'message_action', callback_id: 'another_message_action_callback_id' }, ({ }) => { actionFn(); });
+          app.action({ type: 'message_action', callback_id: 'does_not_exist' }, ({ }) => { actionFn(); });
           app.action({ callback_id: 'interactive_message_callback_id' }, ({ }) => { actionFn(); });
           app.action({ callback_id: 'dialog_submission_callback_id' }, ({ }) => { actionFn(); });
           app.view('view_callback_id', ({ }) => { viewFn(); });
@@ -480,7 +493,7 @@ describe('App', () => {
           await delay();
 
           // Assert
-          assert.equal(actionFn.callCount, 4);
+          assert.equal(actionFn.callCount, 5);
           assert.equal(viewFn.callCount, 2);
           assert.equal(optionsFn.callCount, 2);
           assert.equal(ackFn.callCount, dummyReceiverEvents.length);

--- a/src/App.ts
+++ b/src/App.ts
@@ -87,6 +87,7 @@ export interface AuthorizeResult {
 }
 
 export interface ActionConstraints {
+  type?: string,
   block_id?: string | RegExp;
   action_id?: string | RegExp;
   callback_id?: string | RegExp;
@@ -282,7 +283,7 @@ export default class App {
 
     // Fail early if the constraints contain invalid keys
     const unknownConstraintKeys = Object.keys(constraints)
-      .filter(k => (k !== 'action_id' && k !== 'block_id' && k !== 'callback_id'));
+      .filter(k => (k !== 'action_id' && k !== 'block_id' && k !== 'callback_id' && k !== 'type'));
     if (unknownConstraintKeys.length > 0) {
       this.logger.error(
         `Action listener cannot be attached using unknown constraint keys: ${unknownConstraintKeys.join(', ')}`,

--- a/src/types/actions/index.ts
+++ b/src/types/actions/index.ts
@@ -10,7 +10,7 @@ import { MessageAction } from './message-action';
 import { SayFn, SayArguments, RespondFn, AckFn } from '../utilities';
 
 /**
- * All known actions from Slack's Blot Kit interactive components, message actions, dialogs, and legacy interactive
+ * All known actions from Slack's Block Kit interactive components, message actions, dialogs, and legacy interactive
  * messages.
  *
  * TODO: BlockAction's default generic parameter (ElementAction) might be too specific to allow for this type to be used


### PR DESCRIPTION
###  Summary
This adds `type` as an additional constraint for actions.  Motivation for this is to allow slightly more flexibility for routing specific types of actions to certain handlers.  Being able to constrain by `type` allows you to route actions that may have different `types` but the same `action_id` (or other constraint properties), or even route all actions of a specific `type` to one handler (regardless of `callback_id`, `action_id` or `block_id`.

In response to https://github.com/slackapi/bolt/issues/325

![both](https://user-images.githubusercontent.com/367275/70172041-25e22980-168d-11ea-95d9-7da707aa04d2.gif)

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
