### PR TITLE
Fire im_open event for the bot

### DIFF
--- a/src/middleware/builtin.ts
+++ b/src/middleware/builtin.ts
@@ -270,6 +270,7 @@ export function ignoreSelf(): Middleware<AnyMiddlewareArgs> {
       const eventsWhichShouldBeKept = [
         'member_joined_channel',
         'member_left_channel',
+        'im_open',
       ];
       const isEventShouldBeKept = eventsWhichShouldBeKept.includes(args.event.type);
 


### PR DESCRIPTION
###  Summary

This PR partially relates to #236.

**Consider the use case:**
Show a list of supported slash commands, messages, etc when the user opens IM with the bot for the very first time.

In order to implement that, you have to subscribe to the `im_open` event, but this event isn't fired for your bot.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).