### PR TITLE
Updated web-api dependency to 5.6.0. #334

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "@slack/logger": ">=1.0.0 <3.0.0",
     "@slack/types": "^1.2.1",
-    "@slack/web-api": "^5.2.1",
+    "@slack/web-api": "^5.6.0",
     "@types/express": "^4.16.1",
     "@types/node": ">=10",
     "axios": "^0.18.1",


### PR DESCRIPTION
###  Summary

Issue 334, updated `web-api` dependency to `5.6.0`. This way when folks update their bolt dependency, they will get the newer `web-api` which includes support for granular bot permissions. 

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).