### PR TITLE
🧹 mostly low-hanging ts lint fixes, ts lint as part of test

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ called with arguments that make it easy to build a rich app.
    types of data are only available outside the event payload itself, such as `api_app_id`, `authed_users`, etc. This
    argument should rarely be needed, but for completeness it is provided here.
 
-The arguments are grouped into properties of one object, so that its easier to pick just the ones your listener needs
+The arguments are grouped into properties of one object, so that it's easier to pick just the ones your listener needs
 (using
 [object destructuring](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment#Unpacking_fields_from_objects_passed_as_function_parameter)).
 Here is an example where the app sends a simple response, so there's no need for most of these arguments:
@@ -173,7 +173,7 @@ app.action({ callbackId: 'my_dialog_callback' }, async ({ action, ack }) => {
 
 ## Handling errors
 
-If an error occurs in a listener function, its strongly recommended to handle it directly. There are a few cases where
+If an error occurs in a listener function, it's strongly recommended to handle it directly. There are a few cases where
 those errors may occur after your listener function has returned (such as when calling `say()` or `respond()`, or
 forgetting to call `ack()`). In these cases, your app will be notified about the error in an error handler function.
 Your app should register an error handler using the `App#error(fn)` method.
@@ -239,7 +239,7 @@ app.message('whoami', ({ say, context }) => { say(`User Details: ${JSON.stringif
 })();
 
 // Authentication middleware - Calls Acme identity provider to associate the incoming event with the user who sent it
-// Its a function just like listeners, but it also uses the next argument
+// It's a function just like listeners, but it also uses the next argument
 function authWithAcme({ payload, context, say, next }) {
   const slackUserId = payload.user;
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "build": "tsc",
     "build:clean": "shx rm -rf ./dist ./coverage ./.nyc_output",
     "lint": "tslint --project .",
-    "test": "nyc mocha --config .mocharc.json \"src/**/*.spec.ts\"",
+    "mocha": "nyc mocha --config .mocharc.json \"src/**/*.spec.ts\"",
+    "test": "npm run lint && npm run mocha",
     "coverage": "codecov"
   },
   "repository": "slackapi/bolt",

--- a/src/App.ts
+++ b/src/App.ts
@@ -83,11 +83,11 @@ export interface AuthorizeResult {
   userToken?: string; // used by `say` (overridden by botToken)
   botId?: string; // required for `ignoreSelf` global middleware
   botUserId?: string; // optional but allows `ignoreSelf` global middleware be more filter more than just message events
-  [ key: string ]: any;
+  [key: string]: any;
 }
 
 export interface ActionConstraints {
-  type?: string,
+  type?: string;
   block_id?: string | RegExp;
   action_id?: string | RegExp;
   callback_id?: string | RegExp;
@@ -279,7 +279,7 @@ export default class App {
   ): void {
     const constraints: ActionConstraints =
       (typeof actionIdOrConstraints === 'string' || util.types.isRegExp(actionIdOrConstraints)) ?
-      { action_id: actionIdOrConstraints } : actionIdOrConstraints;
+        { action_id: actionIdOrConstraints } : actionIdOrConstraints;
 
     // Fail early if the constraints contain invalid keys
     const unknownConstraintKeys = Object.keys(constraints)
@@ -317,7 +317,7 @@ export default class App {
   ): void {
     const constraints: ActionConstraints =
       (typeof actionIdOrConstraints === 'string' || util.types.isRegExp(actionIdOrConstraints)) ?
-      { action_id: actionIdOrConstraints } : actionIdOrConstraints;
+        { action_id: actionIdOrConstraints } : actionIdOrConstraints;
 
     this.listeners.push(
       [onlyOptions, matchConstraints(constraints), ...listeners] as Middleware<AnyMiddlewareArgs>[],
@@ -337,7 +337,7 @@ export default class App {
     ...listeners: Middleware<SlackViewMiddlewareArgs<ViewActionType>>[]): void {
     const constraints: ViewConstraints =
       (typeof callbackIdOrConstraints === 'string' || util.types.isRegExp(callbackIdOrConstraints)) ?
-      { callback_id: callbackIdOrConstraints, type: 'view_submission' } : callbackIdOrConstraints;
+        { callback_id: callbackIdOrConstraints, type: 'view_submission' } : callbackIdOrConstraints;
     // Fail early if the constraints contain invalid keys
     const unknownConstraintKeys = Object.keys(constraints)
       .filter(k => (k !== 'callback_id' && k !== 'type'));
@@ -407,29 +407,39 @@ export default class App {
     // Set body and payload (this value will eventually conform to AnyMiddlewareArgs)
     // NOTE: the following doesn't work because... distributive?
     // const listenerArgs: Partial<AnyMiddlewareArgs> = {
-    const listenerArgs:
-      Pick<AnyMiddlewareArgs, 'body' | 'payload'> & {
-        /** Say function might be set below */
-        say?: SayFn
-        /** Respond function might be set below */
-        respond?: RespondFn,
-        /** Ack function might be set below */
-        ack?: AckFn<any>,
-      } = {
-        body: bodyArg,
-        payload:
-          (type === IncomingEventType.Event) ?
-            (bodyArg as SlackEventMiddlewareArgs['body']).event :
-          (type === IncomingEventType.ViewAction) ?
-            (bodyArg as SlackViewMiddlewareArgs['body']).view :
-          (type === IncomingEventType.Action &&
-            isBlockActionOrInteractiveMessageBody(bodyArg as SlackActionMiddlewareArgs['body'])) ?
-            (bodyArg as SlackActionMiddlewareArgs<BlockAction | InteractiveMessage>['body']).actions[0] :
-          (bodyArg as (
-            Exclude<AnyMiddlewareArgs, SlackEventMiddlewareArgs | SlackActionMiddlewareArgs | SlackViewMiddlewareArgs> |
-            SlackActionMiddlewareArgs<Exclude<SlackAction, BlockAction | InteractiveMessage>>
-          )['body']),
-      };
+    const listenerArgs: Pick<AnyMiddlewareArgs, 'body' | 'payload'> & {
+      /** Say function might be set below */
+      say?: SayFn
+      /** Respond function might be set below */
+      respond?: RespondFn,
+      /** Ack function might be set below */
+      ack?: AckFn<any>,
+    } = {
+      body: bodyArg,
+      payload:
+        type === IncomingEventType.Event
+          ? (bodyArg as SlackEventMiddlewareArgs['body']).event
+          : type === IncomingEventType.ViewAction
+            ? (bodyArg as SlackViewMiddlewareArgs['body']).view
+            : type === IncomingEventType.Action &&
+              isBlockActionOrInteractiveMessageBody(
+                bodyArg as SlackActionMiddlewareArgs['body'],
+              )
+              ? (bodyArg as SlackActionMiddlewareArgs<
+                BlockAction | InteractiveMessage
+              >['body']).actions[0]
+              : (bodyArg as (
+                | Exclude<
+                  AnyMiddlewareArgs,
+                  | SlackEventMiddlewareArgs
+                  | SlackActionMiddlewareArgs
+                  | SlackViewMiddlewareArgs
+                >
+                | SlackActionMiddlewareArgs<
+                  Exclude<SlackAction, BlockAction | InteractiveMessage>
+                >
+              )['body']),
+    };
 
     // Set aliases
     if (type === IncomingEventType.Event) {
@@ -529,22 +539,22 @@ function buildSource(
   const source: AuthorizeSourceData = {
     teamId:
       ((type === IncomingEventType.Event || type === IncomingEventType.Command) ? (body as (SlackEventMiddlewareArgs | SlackCommandMiddlewareArgs)['body']).team_id as string :
-       (type === IncomingEventType.Action || type === IncomingEventType.Options || type === IncomingEventType.ViewAction) ? (body as (SlackActionMiddlewareArgs | SlackOptionsMiddlewareArgs | SlackViewMiddlewareArgs)['body']).team.id as string :
-       assertNever(type)),
+        (type === IncomingEventType.Action || type === IncomingEventType.Options || type === IncomingEventType.ViewAction) ? (body as (SlackActionMiddlewareArgs | SlackOptionsMiddlewareArgs | SlackViewMiddlewareArgs)['body']).team.id as string :
+          assertNever(type)),
     enterpriseId:
       ((type === IncomingEventType.Event || type === IncomingEventType.Command) ? (body as (SlackEventMiddlewareArgs | SlackCommandMiddlewareArgs)['body']).enterprise_id as string :
-       (type === IncomingEventType.Action || type === IncomingEventType.Options || type === IncomingEventType.ViewAction) ? (body as (SlackActionMiddlewareArgs | SlackOptionsMiddlewareArgs | SlackViewMiddlewareArgs)['body']).team.enterprise_id as string :
-       undefined),
+        (type === IncomingEventType.Action || type === IncomingEventType.Options || type === IncomingEventType.ViewAction) ? (body as (SlackActionMiddlewareArgs | SlackOptionsMiddlewareArgs | SlackViewMiddlewareArgs)['body']).team.enterprise_id as string :
+          undefined),
     userId:
       ((type === IncomingEventType.Event) ?
         ((typeof (body as SlackEventMiddlewareArgs['body']).event.user === 'string') ? (body as SlackEventMiddlewareArgs['body']).event.user as string :
-         (typeof (body as SlackEventMiddlewareArgs['body']).event.user === 'object') ? (body as SlackEventMiddlewareArgs['body']).event.user.id as string :
-         ((body as SlackEventMiddlewareArgs['body']).event.channel !== undefined && (body as SlackEventMiddlewareArgs['body']).event.channel.creator !== undefined) ? (body as SlackEventMiddlewareArgs['body']).event.channel.creator as string :
-         ((body as SlackEventMiddlewareArgs['body']).event.subteam !== undefined && (body as SlackEventMiddlewareArgs['body']).event.subteam.created_by !== undefined) ? (body as SlackEventMiddlewareArgs['body']).event.subteam.created_by as string :
-         undefined) :
-       (type === IncomingEventType.Action || type === IncomingEventType.Options || type === IncomingEventType.ViewAction) ? (body as (SlackActionMiddlewareArgs | SlackOptionsMiddlewareArgs | SlackViewMiddlewareArgs)['body']).user.id as string :
-       (type === IncomingEventType.Command) ? (body as SlackCommandMiddlewareArgs['body']).user_id as string :
-       undefined),
+          (typeof (body as SlackEventMiddlewareArgs['body']).event.user === 'object') ? (body as SlackEventMiddlewareArgs['body']).event.user.id as string :
+            ((body as SlackEventMiddlewareArgs['body']).event.channel !== undefined && (body as SlackEventMiddlewareArgs['body']).event.channel.creator !== undefined) ? (body as SlackEventMiddlewareArgs['body']).event.channel.creator as string :
+              ((body as SlackEventMiddlewareArgs['body']).event.subteam !== undefined && (body as SlackEventMiddlewareArgs['body']).event.subteam.created_by !== undefined) ? (body as SlackEventMiddlewareArgs['body']).event.subteam.created_by as string :
+                undefined) :
+        (type === IncomingEventType.Action || type === IncomingEventType.Options || type === IncomingEventType.ViewAction) ? (body as (SlackActionMiddlewareArgs | SlackOptionsMiddlewareArgs | SlackViewMiddlewareArgs)['body']).user.id as string :
+          (type === IncomingEventType.Command) ? (body as SlackCommandMiddlewareArgs['body']).user_id as string :
+            undefined),
     conversationId: channelId,
   };
   // tslint:enable:max-line-length

--- a/src/App.ts
+++ b/src/App.ts
@@ -83,11 +83,11 @@ export interface AuthorizeResult {
   userToken?: string; // used by `say` (overridden by botToken)
   botId?: string; // required for `ignoreSelf` global middleware
   botUserId?: string; // optional but allows `ignoreSelf` global middleware be more filter more than just message events
-  [key: string]: any;
+  [ key: string ]: any;
 }
 
 export interface ActionConstraints {
-  type?: string;
+  type?: string,
   block_id?: string | RegExp;
   action_id?: string | RegExp;
   callback_id?: string | RegExp;
@@ -279,7 +279,7 @@ export default class App {
   ): void {
     const constraints: ActionConstraints =
       (typeof actionIdOrConstraints === 'string' || util.types.isRegExp(actionIdOrConstraints)) ?
-        { action_id: actionIdOrConstraints } : actionIdOrConstraints;
+      { action_id: actionIdOrConstraints } : actionIdOrConstraints;
 
     // Fail early if the constraints contain invalid keys
     const unknownConstraintKeys = Object.keys(constraints)
@@ -317,7 +317,7 @@ export default class App {
   ): void {
     const constraints: ActionConstraints =
       (typeof actionIdOrConstraints === 'string' || util.types.isRegExp(actionIdOrConstraints)) ?
-        { action_id: actionIdOrConstraints } : actionIdOrConstraints;
+      { action_id: actionIdOrConstraints } : actionIdOrConstraints;
 
     this.listeners.push(
       [onlyOptions, matchConstraints(constraints), ...listeners] as Middleware<AnyMiddlewareArgs>[],
@@ -337,7 +337,7 @@ export default class App {
     ...listeners: Middleware<SlackViewMiddlewareArgs<ViewActionType>>[]): void {
     const constraints: ViewConstraints =
       (typeof callbackIdOrConstraints === 'string' || util.types.isRegExp(callbackIdOrConstraints)) ?
-        { callback_id: callbackIdOrConstraints, type: 'view_submission' } : callbackIdOrConstraints;
+      { callback_id: callbackIdOrConstraints, type: 'view_submission' } : callbackIdOrConstraints;
     // Fail early if the constraints contain invalid keys
     const unknownConstraintKeys = Object.keys(constraints)
       .filter(k => (k !== 'callback_id' && k !== 'type'));
@@ -417,28 +417,17 @@ export default class App {
     } = {
       body: bodyArg,
       payload:
-        type === IncomingEventType.Event
-          ? (bodyArg as SlackEventMiddlewareArgs['body']).event
-          : type === IncomingEventType.ViewAction
-            ? (bodyArg as SlackViewMiddlewareArgs['body']).view
-            : type === IncomingEventType.Action &&
-              isBlockActionOrInteractiveMessageBody(
-                bodyArg as SlackActionMiddlewareArgs['body'],
-              )
-              ? (bodyArg as SlackActionMiddlewareArgs<
-                BlockAction | InteractiveMessage
-              >['body']).actions[0]
-              : (bodyArg as (
-                | Exclude<
-                  AnyMiddlewareArgs,
-                  | SlackEventMiddlewareArgs
-                  | SlackActionMiddlewareArgs
-                  | SlackViewMiddlewareArgs
-                >
-                | SlackActionMiddlewareArgs<
-                  Exclude<SlackAction, BlockAction | InteractiveMessage>
-                >
-              )['body']),
+        (type === IncomingEventType.Event) ?
+          (bodyArg as SlackEventMiddlewareArgs['body']).event :
+        (type === IncomingEventType.ViewAction) ?
+          (bodyArg as SlackViewMiddlewareArgs['body']).view :
+        (type === IncomingEventType.Action &&
+          isBlockActionOrInteractiveMessageBody(bodyArg as SlackActionMiddlewareArgs['body'])) ?
+          (bodyArg as SlackActionMiddlewareArgs<BlockAction | InteractiveMessage>['body']).actions[0] :
+        (bodyArg as (
+          Exclude<AnyMiddlewareArgs, SlackEventMiddlewareArgs | SlackActionMiddlewareArgs | SlackViewMiddlewareArgs> |
+          SlackActionMiddlewareArgs<Exclude<SlackAction, BlockAction | InteractiveMessage>>
+        )['body']),
     };
 
     // Set aliases
@@ -539,22 +528,22 @@ function buildSource(
   const source: AuthorizeSourceData = {
     teamId:
       ((type === IncomingEventType.Event || type === IncomingEventType.Command) ? (body as (SlackEventMiddlewareArgs | SlackCommandMiddlewareArgs)['body']).team_id as string :
-        (type === IncomingEventType.Action || type === IncomingEventType.Options || type === IncomingEventType.ViewAction) ? (body as (SlackActionMiddlewareArgs | SlackOptionsMiddlewareArgs | SlackViewMiddlewareArgs)['body']).team.id as string :
-          assertNever(type)),
+       (type === IncomingEventType.Action || type === IncomingEventType.Options || type === IncomingEventType.ViewAction) ? (body as (SlackActionMiddlewareArgs | SlackOptionsMiddlewareArgs | SlackViewMiddlewareArgs)['body']).team.id as string :
+       assertNever(type)),
     enterpriseId:
       ((type === IncomingEventType.Event || type === IncomingEventType.Command) ? (body as (SlackEventMiddlewareArgs | SlackCommandMiddlewareArgs)['body']).enterprise_id as string :
-        (type === IncomingEventType.Action || type === IncomingEventType.Options || type === IncomingEventType.ViewAction) ? (body as (SlackActionMiddlewareArgs | SlackOptionsMiddlewareArgs | SlackViewMiddlewareArgs)['body']).team.enterprise_id as string :
-          undefined),
+       (type === IncomingEventType.Action || type === IncomingEventType.Options || type === IncomingEventType.ViewAction) ? (body as (SlackActionMiddlewareArgs | SlackOptionsMiddlewareArgs | SlackViewMiddlewareArgs)['body']).team.enterprise_id as string :
+       undefined),
     userId:
       ((type === IncomingEventType.Event) ?
         ((typeof (body as SlackEventMiddlewareArgs['body']).event.user === 'string') ? (body as SlackEventMiddlewareArgs['body']).event.user as string :
-          (typeof (body as SlackEventMiddlewareArgs['body']).event.user === 'object') ? (body as SlackEventMiddlewareArgs['body']).event.user.id as string :
-            ((body as SlackEventMiddlewareArgs['body']).event.channel !== undefined && (body as SlackEventMiddlewareArgs['body']).event.channel.creator !== undefined) ? (body as SlackEventMiddlewareArgs['body']).event.channel.creator as string :
-              ((body as SlackEventMiddlewareArgs['body']).event.subteam !== undefined && (body as SlackEventMiddlewareArgs['body']).event.subteam.created_by !== undefined) ? (body as SlackEventMiddlewareArgs['body']).event.subteam.created_by as string :
-                undefined) :
-        (type === IncomingEventType.Action || type === IncomingEventType.Options || type === IncomingEventType.ViewAction) ? (body as (SlackActionMiddlewareArgs | SlackOptionsMiddlewareArgs | SlackViewMiddlewareArgs)['body']).user.id as string :
-          (type === IncomingEventType.Command) ? (body as SlackCommandMiddlewareArgs['body']).user_id as string :
-            undefined),
+         (typeof (body as SlackEventMiddlewareArgs['body']).event.user === 'object') ? (body as SlackEventMiddlewareArgs['body']).event.user.id as string :
+         ((body as SlackEventMiddlewareArgs['body']).event.channel !== undefined && (body as SlackEventMiddlewareArgs['body']).event.channel.creator !== undefined) ? (body as SlackEventMiddlewareArgs['body']).event.channel.creator as string :
+         ((body as SlackEventMiddlewareArgs['body']).event.subteam !== undefined && (body as SlackEventMiddlewareArgs['body']).event.subteam.created_by !== undefined) ? (body as SlackEventMiddlewareArgs['body']).event.subteam.created_by as string :
+         undefined) :
+       (type === IncomingEventType.Action || type === IncomingEventType.Options || type === IncomingEventType.ViewAction) ? (body as (SlackActionMiddlewareArgs | SlackOptionsMiddlewareArgs | SlackViewMiddlewareArgs)['body']).user.id as string :
+       (type === IncomingEventType.Command) ? (body as SlackCommandMiddlewareArgs['body']).user_id as string :
+       undefined),
     conversationId: channelId,
   };
   // tslint:enable:max-line-length

--- a/src/App.ts
+++ b/src/App.ts
@@ -87,7 +87,7 @@ export interface AuthorizeResult {
 }
 
 export interface ActionConstraints {
-  type?: string,
+  type?: string;
   block_id?: string | RegExp;
   action_id?: string | RegExp;
   callback_id?: string | RegExp;

--- a/src/ExpressReceiver.spec.ts
+++ b/src/ExpressReceiver.spec.ts
@@ -108,13 +108,24 @@ describe('ExpressReceiver', () => {
       })
     }
 
-    it('should detect headers missing', async () => {
+    it('should detect headers missing signature', async () => {
       const reqAsStream = new Readable();
       reqAsStream.push(body);
       reqAsStream.push(null); // indicate EOF
       (reqAsStream as { [key: string]: any }).headers = {
-        'x-slack-signature': signature /*,
-        'x-slack-request-timestamp': requestTimestamp */
+        // 'x-slack-signature': signature ,
+        'x-slack-request-timestamp': requestTimestamp
+      };
+      await verifyMissingHeaderDetection(reqAsStream as Request);
+    });
+
+    it('should detect headers missing timestamp', async () => {
+      const reqAsStream = new Readable();
+      reqAsStream.push(body);
+      reqAsStream.push(null); // indicate EOF
+      (reqAsStream as { [key: string]: any }).headers = {
+        'x-slack-signature': signature /* ,
+        'x-slack-request-timestamp': requestTimestamp*/
       };
       await verifyMissingHeaderDetection(reqAsStream as Request);
     });

--- a/src/ExpressReceiver.spec.ts
+++ b/src/ExpressReceiver.spec.ts
@@ -198,9 +198,9 @@ describe('ExpressReceiver', () => {
     });
 
     // ----------------------------
-    // verifySingnatureMismatch
+    // verifySignatureMismatch
 
-    function verifySingnatureMismatch(req: Request): Promise<any> {
+    function verifySignatureMismatch(req: Request): Promise<any> {
       // Arrange
       const resp = {} as Response;
       let errorResult: any;
@@ -224,7 +224,7 @@ describe('ExpressReceiver', () => {
         'x-slack-request-timestamp': requestTimestamp + 10
       };
       const req = reqAsStream as Request;
-      await verifySingnatureMismatch(req);
+      await verifySignatureMismatch(req);
     });
 
     it('should detect signature mismatch on GCP', async () => {
@@ -236,7 +236,7 @@ describe('ExpressReceiver', () => {
         }
       };
       const req = untypedReq as Request;
-      await verifySingnatureMismatch(req);
+      await verifySignatureMismatch(req);
     });
 
   });

--- a/src/ExpressReceiver.ts
+++ b/src/ExpressReceiver.ts
@@ -218,7 +218,7 @@ async function verifyRequestSignature(
   body: string,
   signature: string,
   requestTimestamp: number): Promise<void> {
-  if (signature === undefined || requestTimestamp === undefined) {
+  if (signature === undefined || isNaN(requestTimestamp)) {
     const error = errorWithCode(
       'Slack request signing verification failed. Some headers are missing.',
       ErrorCode.ExpressReceiverAuthenticityError,

--- a/src/ExpressReceiver.ts
+++ b/src/ExpressReceiver.ts
@@ -134,7 +134,7 @@ export default class ExpressReceiver extends EventEmitter implements Receiver {
     return new Promise((resolve, reject) => {
       // TODO: what about synchronous errors?
       this.server.close((error) => {
-        if (Boolean(error)) {
+        if (error !== undefined) {
           reject(error);
           return;
         }
@@ -218,7 +218,7 @@ async function verifyRequestSignature(
   body: string,
   signature: string,
   requestTimestamp: number): Promise<void> {
-  if (!Boolean(signature) || !Boolean(requestTimestamp)) {
+  if (signature === undefined || requestTimestamp === undefined) {
     const error = errorWithCode(
       'Slack request signing verification failed. Some headers are missing.',
       ErrorCode.ExpressReceiverAuthenticityError,
@@ -254,7 +254,7 @@ async function verifyRequestSignature(
 function parseRequestBody(
   logger: Logger,
   stringBody: string,
-  contentType: string | undefined): string | querystring.ParsedUrlQuery {
+  contentType: string | undefined): any {
   if (contentType === 'application/x-www-form-urlencoded') {
     const parsedBody = querystring.parse(stringBody);
     if (typeof parsedBody.payload === 'string') {

--- a/src/ExpressReceiver.ts
+++ b/src/ExpressReceiver.ts
@@ -174,7 +174,8 @@ const respondToUrlVerification: RequestHandler = (req, res, next) => {
  */
 export function verifySignatureAndParseBody(
   logger: Logger,
-  signingSecret: string): RequestHandler {
+  signingSecret: string,
+): RequestHandler {
   return async (req, _res, next) => {
     try {
       // *** Request verification ***
@@ -187,14 +188,19 @@ export function verifySignatureAndParseBody(
       } else {
         stringBody = (await rawBody(req)).toString();
       }
-      const signature = req.headers['x-slack-signature'] as string;
-      const ts = Number(req.headers['x-slack-request-timestamp']);
 
-      try {
-        await verifyRequestSignature(signingSecret, stringBody, signature, ts);
-      } catch (e) {
-        return next(e);
-      }
+      const {
+        'x-slack-signature': signature,
+        'x-slack-request-timestamp': requestTimestamp,
+        'content-type': contentType,
+      } = req.headers;
+
+      await verifyRequestSignature(
+        signingSecret,
+        stringBody,
+        signature as string | undefined,
+        requestTimestamp as string | undefined,
+      );
 
       // *** Parsing body ***
       // As the verification passed, parse the body as an object and assign it to req.body
@@ -202,12 +208,11 @@ export function verifySignatureAndParseBody(
 
       // This handler parses `req.body` or `req.rawBody`(on Google Could Platform)
       // and overwrites `req.body` with the parsed JS object.
-      const contentType = req.headers['content-type'];
       req.body = parseRequestBody(logger, stringBody, contentType);
 
-      next();
+      return next();
     } catch (error) {
-      next(error);
+      return next(error);
     }
   };
 }
@@ -216,38 +221,44 @@ export function verifySignatureAndParseBody(
 async function verifyRequestSignature(
   signingSecret: string,
   body: string,
-  signature: string,
-  requestTimestamp: number): Promise<void> {
-  if (signature === undefined || isNaN(requestTimestamp)) {
-    const error = errorWithCode(
+  signature: string | undefined,
+  requestTimestamp: string | undefined,
+): Promise<void> {
+  if (signature === undefined || requestTimestamp === undefined) {
+    throw errorWithCode(
       'Slack request signing verification failed. Some headers are missing.',
       ErrorCode.ExpressReceiverAuthenticityError,
     );
-    throw error;
+  }
+
+  const ts = Number(requestTimestamp);
+  if (isNaN(ts)) {
+    throw errorWithCode(
+      'Slack request signing verification failed. Timestamp is invalid.',
+      ErrorCode.ExpressReceiverAuthenticityError,
+    );
   }
 
   // Divide current date to match Slack ts format
   // Subtract 5 minutes from current time
   const fiveMinutesAgo = Math.floor(Date.now() / 1000) - (60 * 5);
 
-  if (requestTimestamp < fiveMinutesAgo) {
-    const error = errorWithCode(
+  if (ts < fiveMinutesAgo) {
+    throw errorWithCode(
       'Slack request signing verification failed. Timestamp is too old.',
       ErrorCode.ExpressReceiverAuthenticityError,
     );
-    throw error;
   }
 
   const hmac = crypto.createHmac('sha256', signingSecret);
   const [version, hash] = signature.split('=');
-  hmac.update(`${version}:${requestTimestamp}:${body}`);
+  hmac.update(`${version}:${ts}:${body}`);
 
   if (!tsscmp(hash, hmac.digest('hex'))) {
-    const error = errorWithCode(
+    throw errorWithCode(
       'Slack request signing verification failed. Signature mismatch.',
       ErrorCode.ExpressReceiverAuthenticityError,
     );
-    throw error;
   }
 }
 

--- a/src/conversation-store.ts
+++ b/src/conversation-store.ts
@@ -69,7 +69,8 @@ export function conversationContext<ConversationState = any>(
         .catch((error) => {
           logger.debug(`Conversation context not loaded: ${error.message}`);
         })
-        .then(next);
+        .then(next)
+        .catch(error => logger.debug(error.message));
     } else {
       logger.debug('No conversation ID for incoming event');
       next();

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -31,7 +31,7 @@ export function getTypeAndConversation(body: any): { type?: IncomingEventType, c
       type: IncomingEventType.Event,
       conversationId:
         eventBody.event.channel !== undefined ? eventBody.event.channel :
-        eventBody.event.item !== undefined ? eventBody.event.item.channel : undefined,
+          eventBody.event.item !== undefined ? eventBody.event.item.channel : undefined,
     };
   }
   if (body.command !== undefined) {
@@ -44,7 +44,7 @@ export function getTypeAndConversation(body: any): { type?: IncomingEventType, c
     const optionsBody = (body as SlackOptionsMiddlewareArgs<OptionsSource>['body']);
     return {
       type: IncomingEventType.Options,
-      conversationId: optionsBody.channel ? optionsBody.channel.id : undefined,
+      conversationId: optionsBody.channel !== undefined ? optionsBody.channel.id : undefined,
     };
   }
   if (body.actions !== undefined || body.type === 'dialog_submission' || body.type === 'message_action') {


### PR DESCRIPTION
###  Summary

Some simple typescript lint fixes. Understand the move might be to eslint at some point, but these still seem like they won't hurt anyone.

Fixes all of these errors but the `conversion-store` promise one.

![image](https://user-images.githubusercontent.com/1487463/70669170-97007e80-1c43-11ea-9f7c-cb91ff01b260.png)

Left comments to further elaborate.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).