### PR TITLE
 Fix #341 - Make channel file in block_actions payload optional (+ add view field)

### DIFF
--- a/src/types/actions/block-action.ts
+++ b/src/types/actions/block-action.ts
@@ -1,4 +1,4 @@
-import { PlainTextElement, Confirmation, Option } from '@slack/types';
+import { PlainTextElement, Confirmation, Option, View } from '@slack/types';
 import { StringIndexed } from '../helpers';
 
 /**
@@ -152,6 +152,7 @@ export interface BlockAction<ElementAction extends BasicElementAction = BlockEle
     text?: string; // undocumented that this is optional, but how could it exist on block kit based messages?
     [key: string]: any;
   };
+  view?: View;
   token: string;
   response_url: string;
   trigger_id: string;

--- a/src/types/actions/block-action.ts
+++ b/src/types/actions/block-action.ts
@@ -141,7 +141,7 @@ export interface BlockAction<ElementAction extends BasicElementAction = BlockEle
     name: string;
     team_id?: string; // undocumented
   };
-  channel: {
+  channel?: {
     id: string;
     name: string;
   };


### PR DESCRIPTION
###  Summary

This pull request fixes issue #341 that affects TypeScript users. In connection with this, I've added the missing `view` field for the cases of modals and Home tab.

Also, I noticed `block_actions` payload **in TypeScript** doesn't support multi-select block elements yet. I filed another issue https://github.com/slackapi/bolt/issues/342 and will work on it in a separate pull request.

### Requirements (place an `x` in each `[ ]`)

* [ ] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [ ] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).