### PR TITLE
Remove users info api call

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -430,8 +430,9 @@ export default class App {
               isBlockActionOrInteractiveMessageBody(bodyArg as SlackActionMiddlewareArgs['body'])) ?
               (bodyArg as SlackActionMiddlewareArgs<BlockAction | InteractiveMessage>['body']).actions[0] :
               (bodyArg as (
-                Exclude<AnyMiddlewareArgs, SlackEventMiddlewareArgs | SlackActionMiddlewareArgs | SlackViewMiddlewareArgs> |
-                SlackActionMiddlewareArgs<Exclude<SlackAction, BlockAction | InteractiveMessage>>
+                Exclude<AnyMiddlewareArgs, SlackEventMiddlewareArgs | SlackActionMiddlewareArgs |
+                  SlackViewMiddlewareArgs> | SlackActionMiddlewareArgs<Exclude<SlackAction, BlockAction |
+                    InteractiveMessage>>
               )['body']),
     };
 
@@ -576,17 +577,19 @@ function singleTeamAuthorization(
   const auth: Promise<AuthConstraints> = authorization.botUserId !== undefined && authorization.botId !== undefined ?
     Promise.resolve({ botUserId: authorization.botUserId, botId: authorization.botId }) :
     client.auth.test({ token: authorization.botToken })
-      .then(result => {
+      .then((result) => {
         return {
           botUserId: (result.user_id as string),
-          botId: (result.bot_id as string)
-        }
+          botId: (result.bot_id as string),
+        };
       });
 
-  return async () => ({
-    botToken: authorization.botToken,
-    botId: (await auth).botId,
-    botUserId: (await auth).botUserId,
+  return () => auth.then((result) => {
+    return {
+      botToken: authorization.botToken,
+      botId: result.botId,
+      botUserId: result.botUserId,
+    };
   });
 }
 

--- a/src/App.ts
+++ b/src/App.ts
@@ -98,13 +98,13 @@ export interface ViewConstraints {
   type?: 'view_closed' | 'view_submission';
 }
 
-export interface ErrorHandler {
-  (error: CodedError): void;
-}
-
 export interface AuthConstraints {
   botUserId: string;
   botId: string;
+}
+
+export interface ErrorHandler {
+  (error: CodedError): void;
 }
 
 /**

--- a/src/App.ts
+++ b/src/App.ts
@@ -83,7 +83,7 @@ export interface AuthorizeResult {
   userToken?: string; // used by `say` (overridden by botToken)
   botId?: string; // required for `ignoreSelf` global middleware
   botUserId?: string; // optional but allows `ignoreSelf` global middleware be more filter more than just message events
-  [ key: string ]: any;
+  [key: string]: any;
 }
 
 export interface ActionConstraints {
@@ -100,6 +100,11 @@ export interface ViewConstraints {
 
 export interface ErrorHandler {
   (error: CodedError): void;
+}
+
+export interface AuthConstraints {
+  botUserId: string;
+  botId: string;
 }
 
 /**
@@ -279,7 +284,7 @@ export default class App {
   ): void {
     const constraints: ActionConstraints =
       (typeof actionIdOrConstraints === 'string' || util.types.isRegExp(actionIdOrConstraints)) ?
-      { action_id: actionIdOrConstraints } : actionIdOrConstraints;
+        { action_id: actionIdOrConstraints } : actionIdOrConstraints;
 
     // Fail early if the constraints contain invalid keys
     const unknownConstraintKeys = Object.keys(constraints)
@@ -317,7 +322,7 @@ export default class App {
   ): void {
     const constraints: ActionConstraints =
       (typeof actionIdOrConstraints === 'string' || util.types.isRegExp(actionIdOrConstraints)) ?
-      { action_id: actionIdOrConstraints } : actionIdOrConstraints;
+        { action_id: actionIdOrConstraints } : actionIdOrConstraints;
 
     this.listeners.push(
       [onlyOptions, matchConstraints(constraints), ...listeners] as Middleware<AnyMiddlewareArgs>[],
@@ -337,7 +342,7 @@ export default class App {
     ...listeners: Middleware<SlackViewMiddlewareArgs<ViewActionType>>[]): void {
     const constraints: ViewConstraints =
       (typeof callbackIdOrConstraints === 'string' || util.types.isRegExp(callbackIdOrConstraints)) ?
-      { callback_id: callbackIdOrConstraints, type: 'view_submission' } : callbackIdOrConstraints;
+        { callback_id: callbackIdOrConstraints, type: 'view_submission' } : callbackIdOrConstraints;
     // Fail early if the constraints contain invalid keys
     const unknownConstraintKeys = Object.keys(constraints)
       .filter(k => (k !== 'callback_id' && k !== 'type'));
@@ -419,15 +424,15 @@ export default class App {
       payload:
         (type === IncomingEventType.Event) ?
           (bodyArg as SlackEventMiddlewareArgs['body']).event :
-        (type === IncomingEventType.ViewAction) ?
-          (bodyArg as SlackViewMiddlewareArgs['body']).view :
-        (type === IncomingEventType.Action &&
-          isBlockActionOrInteractiveMessageBody(bodyArg as SlackActionMiddlewareArgs['body'])) ?
-          (bodyArg as SlackActionMiddlewareArgs<BlockAction | InteractiveMessage>['body']).actions[0] :
-        (bodyArg as (
-          Exclude<AnyMiddlewareArgs, SlackEventMiddlewareArgs | SlackActionMiddlewareArgs | SlackViewMiddlewareArgs> |
-          SlackActionMiddlewareArgs<Exclude<SlackAction, BlockAction | InteractiveMessage>>
-        )['body']),
+          (type === IncomingEventType.ViewAction) ?
+            (bodyArg as SlackViewMiddlewareArgs['body']).view :
+            (type === IncomingEventType.Action &&
+              isBlockActionOrInteractiveMessageBody(bodyArg as SlackActionMiddlewareArgs['body'])) ?
+              (bodyArg as SlackActionMiddlewareArgs<BlockAction | InteractiveMessage>['body']).actions[0] :
+              (bodyArg as (
+                Exclude<AnyMiddlewareArgs, SlackEventMiddlewareArgs | SlackActionMiddlewareArgs | SlackViewMiddlewareArgs> |
+                SlackActionMiddlewareArgs<Exclude<SlackAction, BlockAction | InteractiveMessage>>
+              )['body']),
     };
 
     // Set aliases
@@ -528,22 +533,22 @@ function buildSource(
   const source: AuthorizeSourceData = {
     teamId:
       ((type === IncomingEventType.Event || type === IncomingEventType.Command) ? (body as (SlackEventMiddlewareArgs | SlackCommandMiddlewareArgs)['body']).team_id as string :
-       (type === IncomingEventType.Action || type === IncomingEventType.Options || type === IncomingEventType.ViewAction) ? (body as (SlackActionMiddlewareArgs | SlackOptionsMiddlewareArgs | SlackViewMiddlewareArgs)['body']).team.id as string :
-       assertNever(type)),
+        (type === IncomingEventType.Action || type === IncomingEventType.Options || type === IncomingEventType.ViewAction) ? (body as (SlackActionMiddlewareArgs | SlackOptionsMiddlewareArgs | SlackViewMiddlewareArgs)['body']).team.id as string :
+          assertNever(type)),
     enterpriseId:
       ((type === IncomingEventType.Event || type === IncomingEventType.Command) ? (body as (SlackEventMiddlewareArgs | SlackCommandMiddlewareArgs)['body']).enterprise_id as string :
-       (type === IncomingEventType.Action || type === IncomingEventType.Options || type === IncomingEventType.ViewAction) ? (body as (SlackActionMiddlewareArgs | SlackOptionsMiddlewareArgs | SlackViewMiddlewareArgs)['body']).team.enterprise_id as string :
-       undefined),
+        (type === IncomingEventType.Action || type === IncomingEventType.Options || type === IncomingEventType.ViewAction) ? (body as (SlackActionMiddlewareArgs | SlackOptionsMiddlewareArgs | SlackViewMiddlewareArgs)['body']).team.enterprise_id as string :
+          undefined),
     userId:
       ((type === IncomingEventType.Event) ?
         ((typeof (body as SlackEventMiddlewareArgs['body']).event.user === 'string') ? (body as SlackEventMiddlewareArgs['body']).event.user as string :
-         (typeof (body as SlackEventMiddlewareArgs['body']).event.user === 'object') ? (body as SlackEventMiddlewareArgs['body']).event.user.id as string :
-         ((body as SlackEventMiddlewareArgs['body']).event.channel !== undefined && (body as SlackEventMiddlewareArgs['body']).event.channel.creator !== undefined) ? (body as SlackEventMiddlewareArgs['body']).event.channel.creator as string :
-         ((body as SlackEventMiddlewareArgs['body']).event.subteam !== undefined && (body as SlackEventMiddlewareArgs['body']).event.subteam.created_by !== undefined) ? (body as SlackEventMiddlewareArgs['body']).event.subteam.created_by as string :
-         undefined) :
-       (type === IncomingEventType.Action || type === IncomingEventType.Options || type === IncomingEventType.ViewAction) ? (body as (SlackActionMiddlewareArgs | SlackOptionsMiddlewareArgs | SlackViewMiddlewareArgs)['body']).user.id as string :
-       (type === IncomingEventType.Command) ? (body as SlackCommandMiddlewareArgs['body']).user_id as string :
-       undefined),
+          (typeof (body as SlackEventMiddlewareArgs['body']).event.user === 'object') ? (body as SlackEventMiddlewareArgs['body']).event.user.id as string :
+            ((body as SlackEventMiddlewareArgs['body']).event.channel !== undefined && (body as SlackEventMiddlewareArgs['body']).event.channel.creator !== undefined) ? (body as SlackEventMiddlewareArgs['body']).event.channel.creator as string :
+              ((body as SlackEventMiddlewareArgs['body']).event.subteam !== undefined && (body as SlackEventMiddlewareArgs['body']).event.subteam.created_by !== undefined) ? (body as SlackEventMiddlewareArgs['body']).event.subteam.created_by as string :
+                undefined) :
+        (type === IncomingEventType.Action || type === IncomingEventType.Options || type === IncomingEventType.ViewAction) ? (body as (SlackActionMiddlewareArgs | SlackOptionsMiddlewareArgs | SlackViewMiddlewareArgs)['body']).user.id as string :
+          (type === IncomingEventType.Command) ? (body as SlackCommandMiddlewareArgs['body']).user_id as string :
+            undefined),
     conversationId: channelId,
   };
   // tslint:enable:max-line-length
@@ -568,18 +573,20 @@ function singleTeamAuthorization(
   authorization: Partial<AuthorizeResult> & { botToken: Required<AuthorizeResult>['botToken'] },
 ): Authorize {
   // TODO: warn when something needed isn't found
-  const botUserId: Promise<string> = authorization.botUserId !== undefined ?
-    Promise.resolve(authorization.botUserId) :
+  const auth: Promise<AuthConstraints> = authorization.botUserId !== undefined && authorization.botId !== undefined ?
+    Promise.resolve({ botUserId: authorization.botUserId, botId: authorization.botId }) :
     client.auth.test({ token: authorization.botToken })
-      .then(result => result.user_id as string);
-  const botId: Promise<string> = authorization.botId !== undefined ?
-    Promise.resolve(authorization.botId) :
-    botUserId.then(id => client.users.info({ token: authorization.botToken, user: id }))
-      .then(result => ((result.user as any).profile.bot_id as string));
+      .then(result => {
+        return {
+          botUserId: (result.user_id as string),
+          botId: (result.bot_id as string)
+        }
+      });
+
   return async () => ({
     botToken: authorization.botToken,
-    botId: await botId,
-    botUserId: await botUserId,
+    botId: (await auth).botId,
+    botUserId: (await auth).botUserId,
   });
 }
 

--- a/src/ExpressReceiver.ts
+++ b/src/ExpressReceiver.ts
@@ -286,6 +286,7 @@ function parseRequestBody(
     logger.error(`Failed to parse body as JSON data for content-type: ${contentType}`);
     throw e;
   }
+
 }
 
 function receiverAckTimeoutError(message: string): ReceiverAckTimeoutError {


### PR DESCRIPTION
###  Summary

This pull request fixes #346 by removing `users.info` call from SingleTeamAuthorization, since this information is now part of the `auth.test` response payload.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).