### PR TITLE
improved type resolution for action method

### DIFF
--- a/integration-tests/.gitignore
+++ b/integration-tests/.gitignore
@@ -1,0 +1,3 @@
+# node / npm stuff
+/node_modules
+/package-lock.json

--- a/integration-tests/.vscode/launch.json
+++ b/integration-tests/.vscode/launch.json
@@ -18,5 +18,36 @@
             ],
             "cwd": "${workspaceFolder}"
         },
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "npm test",
+            "cwd": "${workspaceFolder}",
+            "runtimeExecutable": "npm",
+            "runtimeArgs": [
+                "run-script", "test"
+            ],
+            "port": 9229
+            
+        },
     ]
 }
+
+/*
+[
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "Integration Type Checker",
+            "program": "${workspaceFolder}/node_modules/dtslint/bin/index.js",
+            "args": [
+                "types"
+            ],
+            "internalConsoleOptions": "openOnSessionStart",
+            "skipFiles": [
+                "<node_internals>/**"
+            ],
+            "cwd": "${workspaceFolder}"
+        },
+    ]
+*/

--- a/integration-tests/.vscode/launch.json
+++ b/integration-tests/.vscode/launch.json
@@ -1,0 +1,39 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "Integration Tests",
+            "program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
+            "args": [
+                "--timeout",
+                "999999",
+                "--colors",
+                "${workspaceFolder}/proxy-test.js"
+            ],
+            "internalConsoleOptions": "openOnSessionStart",
+            "skipFiles": [
+                "<node_internals>/**"
+            ],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "Integration Type Checker",
+            "program": "${workspaceFolder}/node_modules/dtslint/bin/index.js",
+            "args": [
+                "types"
+            ],
+            "internalConsoleOptions": "openOnSessionStart",
+            "skipFiles": [
+                "<node_internals>/**"
+            ],
+            "cwd": "${workspaceFolder}"
+        },
+    ]
+}

--- a/integration-tests/.vscode/launch.json
+++ b/integration-tests/.vscode/launch.json
@@ -7,23 +7,6 @@
         {
             "type": "node",
             "request": "launch",
-            "name": "Integration Tests",
-            "program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
-            "args": [
-                "--timeout",
-                "999999",
-                "--colors",
-                "${workspaceFolder}/proxy-test.js"
-            ],
-            "internalConsoleOptions": "openOnSessionStart",
-            "skipFiles": [
-                "<node_internals>/**"
-            ],
-            "cwd": "${workspaceFolder}"
-        },
-        {
-            "type": "node",
-            "request": "launch",
             "name": "Integration Type Checker",
             "program": "${workspaceFolder}/node_modules/dtslint/bin/index.js",
             "args": [

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -1,0 +1,22 @@
+## Integration tests
+
+This directory contains a minimal project used as an environment in which to run integration tests.
+
+It's important to isolate this test project from the overall project where the package is built in order to eliminate
+assumptions. Specifically, the `package.json` and other configuration files in this directory are meant to include
+the minimum requirements and nothing more. Here are a few ways this is set up:
+
+* The `@types/node` dependency is set to a version that corresponds to the lowest supported node version. This enforces
+  that the distribution should work in projects who have chosen that particular version, since its the most likely to
+  not have types that we accidentally depend on but shouldn't.
+
+* The `typescript` development dependency is set to the most modern version of typescript. It's not important to use the
+  oldest supported version because the `dtslint` tool will run the typechecker result integration tests on each
+  supported version of TypeScript. It reads the oldest supported version from `types/index.d.ts`.
+
+* The `tsconfig.json` file is specifically set to the most strict settings as well as the most minimal requirements.
+  This is specifically chosen to verify that the requirements expressed in the documentation are sufficient and
+  represent the least amount of configuration needed to get the package working.
+
+* In `package.json`, the `"private"` key must remain set to `true`. This enforces that this project doesn't get
+  accidentally published.

--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -9,11 +9,11 @@
     "test:typechecker": "dtslint types"
   },
   "dependencies": {
-    "@slack/bolt": "^1.4.1",
-    "@types/node": "^8.10.43"
+    "@slack/bolt": "file:..",
+    "@types/node": "^10.0.0"
   },
   "devDependencies": {
     "dtslint": "^0.5.4",
-    "typescript": "^3.3.3333"
+    "typescript": "^3.7.3"
   }
 }

--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@slack/bolt-integration-tests",
+  "private": true,
+  "description": "Integration tests for Bolt",
+  "author": "Slack Technologies, Inc.",
+  "license": "MIT",
+  "scripts": {
+    "test": "npm run test:typechecker",
+    "test:typechecker": "dtslint types"
+  },
+  "dependencies": {
+    "@slack/bolt": "^1.4.1",
+    "@types/node": "^8.10.43"
+  },
+  "devDependencies": {
+    "dtslint": "^0.5.4",
+    "typescript": "^3.3.3333"
+  }
+}

--- a/integration-tests/types/action.ts
+++ b/integration-tests/types/action.ts
@@ -1,0 +1,66 @@
+// import App, { ActionConstraints } from '../../src/App';
+// import { MessageAction } from '../../src/types';
+import { App } from '@slack/bolt';
+
+const app = new App({ token: 'TOKEN', signingSecret: 'Signing Secret' });
+
+// calling action method with incorrect an type constraint value should not work
+// $ExpectError
+app.action({ type: 'Something wrong' }, ({ action }) => {
+  return action;
+});
+
+/*
+// Should error because message_action doesn't have type action_id
+// $ Expect Error
+app.action({ type: 'message_action', action_id: 'dafasf' }, ({ action }) => {
+    // NOT WORKING
+    return action;
+});
+*/
+
+// Action in listner should be - MessageAction
+// $ExpectType void
+app.action({ type: 'message_action' }, ({
+  action, // $ExpectType MessageAction
+ }) => {
+  return action;
+});
+
+// $ExpectType void
+app.action({ type: 'block_actions' }, ({
+  action, // $ExpectType BlockElementAction
+ }) => {
+  return action;
+});
+
+// $ExpectType void
+app.action({ type: 'interactive_message' }, ({
+  action, // $ExpectType InteractiveAction
+ }) => {
+  return action;
+});
+
+// $ExpectType void
+app.action({ type: 'dialog_submission' }, ({
+  action, // $ExpectType DialogSubmitAction
+ }) => {
+  return action;
+});
+
+/* TODO: do we import MessageAction from local bolt?
+// If action is parameterized with MessageAction, action argument in callback should be type MessageAction
+// $ Expect Type void
+app.action<MessageAction>({}, ({
+  action // $ Expect Type MessageAction
+ }) => {
+  return action;
+});
+
+// Should error because MessageAction doesn't have an action_id
+// $ Expect Error
+app.actiong<MessageAction>({ action_id: 'dafasf' }, ({ action }) => {
+    // NOT WORKING
+    return action;
+});
+*/

--- a/integration-tests/types/action.ts
+++ b/integration-tests/types/action.ts
@@ -1,6 +1,5 @@
 // import App, { ActionConstraints } from '../../src/App';
-// import { MessageAction } from '../../src/types';
-import { App } from '@slack/bolt';
+import { App, MessageAction } from '@slack/bolt';
 
 const app = new App({ token: 'TOKEN', signingSecret: 'Signing Secret' });
 
@@ -10,11 +9,10 @@ app.action({ type: 'Something wrong' }, ({ action }) => {
   return action;
 });
 
-/*
+/* Not working
 // Should error because message_action doesn't have type action_id
 // $ Expect Error
 app.action({ type: 'message_action', action_id: 'dafasf' }, ({ action }) => {
-    // NOT WORKING
     return action;
 });
 */
@@ -48,15 +46,15 @@ app.action({ type: 'dialog_submission' }, ({
   return action;
 });
 
-/* TODO: do we import MessageAction from local bolt?
 // If action is parameterized with MessageAction, action argument in callback should be type MessageAction
-// $ Expect Type void
+// $ExpectType void
 app.action<MessageAction>({}, ({
-  action // $ Expect Type MessageAction
+  action // $ExpectType MessageAction
  }) => {
   return action;
 });
 
+/* Not working
 // Should error because MessageAction doesn't have an action_id
 // $ Expect Error
 app.actiong<MessageAction>({ action_id: 'dafasf' }, ({ action }) => {

--- a/integration-tests/types/index.d.ts
+++ b/integration-tests/types/index.d.ts
@@ -1,0 +1,2 @@
+// tslint:disable:no-useless-files
+// TypeScript Version: 3.3

--- a/integration-tests/types/tsconfig.json
+++ b/integration-tests/types/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "module": "commonjs",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "lib": ["es5"]
+  }
+}

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "build:clean": "shx rm -rf ./dist ./coverage ./.nyc_output",
     "lint": "tslint --project .",
     "mocha": "nyc mocha --config .mocharc.json \"src/**/*.spec.ts\"",
-    "test": "npm run lint && npm run mocha",
+    "test": "npm run lint && npm run mocha && npm run test:integration",
+    "test:integration": "cd integration-tests && npm install && npm test",
     "coverage": "codecov"
   },
   "repository": "slackapi/bolt",


### PR DESCRIPTION
###  Summary

Related to https://github.com/slackapi/bolt/pull/326 and #325.

A small improvement based on comments by @aoberoi at https://github.com/slackapi/bolt/pull/326#issuecomment-564327258.

Now the action argument gets narrowed down to appropriate action based on type. Example:

```
app1.action({ type: 'block_actions' }, ({ action }) => {
// action is now BlockAction instead of SlackAction
});
```

Currently, no support for the other two use cases @aoberoi pointed out:

1) Typescript should complain about a `type:message_action` also passing an `action_id` (`action_id` is specific to BlockActions)
2) Helping a developer understand what the options might be for the `type` constraint by allowing your editor's inference to give you suggestions.

Still need to add tests for these changes. 

Let me know your thoughts!

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).