### PR TITLE
Add more unit tests for built-in middleware and ExpressReceiver

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,8 +29,9 @@
     "build": "tsc",
     "build:clean": "shx rm -rf ./dist ./coverage ./.nyc_output",
     "lint": "tslint --project .",
+    "test-lint": "tslint \"src/**/*.spec.ts\" && tslint \"src/test-helpers.ts\"",
     "mocha": "nyc mocha --config .mocharc.json \"src/**/*.spec.ts\"",
-    "test": "npm run lint && npm run mocha && npm run test:integration",
+    "test": "npm run lint && npm run test-lint && npm run mocha && npm run test:integration",
     "test:integration": "cd integration-tests && npm install && npm test",
     "coverage": "codecov"
   },

--- a/src/App.spec.ts
+++ b/src/App.spec.ts
@@ -157,23 +157,25 @@ describe('App', () => {
       });
     });
     it('with clientOptions', async () => {
-      const fakeConstructor = sinon.fake()
+      const fakeConstructor = sinon.fake();
       const overrides = mergeOverrides(
         withNoopAppMetadata(),
         {
           '@slack/web-api': {
             WebClient: class {
               constructor() {
-                fakeConstructor(...arguments)
+                fakeConstructor(...arguments);
               }
             },
-          }
-        }
-      )
+          },
+        },
+      );
+      // tslint:disable-next-line: variable-name
       const App = await importApp(overrides);
 
       const clientOptions = { slackApiUrl: 'proxy.slack.com' };
-      new App({ authorize: noopAuthorize, signingSecret: '', logLevel: LogLevel.ERROR, clientOptions });
+      // tslint:disable-next-line: no-unused-expression
+      new App({ clientOptions, authorize: noopAuthorize, signingSecret: '', logLevel: LogLevel.ERROR });
 
       assert.ok(fakeConstructor.called);
 
@@ -181,7 +183,7 @@ describe('App', () => {
       assert.strictEqual(undefined, token, 'token should be undefined');
       assert.strictEqual(clientOptions.slackApiUrl, options.slackApiUrl);
       assert.strictEqual(LogLevel.ERROR, options.logLevel, 'override logLevel');
-    })
+    });
     // TODO: tests for ignoreSelf option
     // TODO: tests for logger and logLevel option
     // TODO: tests for providing botId and botUserId options
@@ -322,7 +324,7 @@ describe('App', () => {
       const dummyChannelId = 'CHANNEL_ID';
       let overrides: Override;
 
-      function buildOverrides(secondOverride: Override) {
+      function buildOverrides(secondOverride: Override): Override {
         fakeReceiver = createFakeReceiver();
         fakeErrorHandler = sinon.fake();
         dummyAuthorizationResult = { botToken: '', botId: '' };
@@ -330,7 +332,7 @@ describe('App', () => {
           withNoopAppMetadata(),
           secondOverride,
           withMemoryStore(sinon.fake()),
-          withConversationContext(sinon.fake.returns(noopMiddleware))
+          withConversationContext(sinon.fake.returns(noopMiddleware)),
         );
         return overrides;
       }
@@ -357,7 +359,7 @@ describe('App', () => {
               body: {
                 type: 'block_actions',
                 actions: [{
-                  action_id: 'block_action_id'
+                  action_id: 'block_action_id',
                 }],
                 channel: {},
                 user: {},
@@ -479,7 +481,9 @@ describe('App', () => {
           app.use((_args) => { ackFn(); });
           app.action('block_action_id', ({ }) => { actionFn(); });
           app.action({ callback_id: 'message_action_callback_id' }, ({ }) => { actionFn(); });
-          app.action({ type: 'message_action', callback_id: 'another_message_action_callback_id' }, ({ }) => { actionFn(); });
+          app.action(
+            { type: 'message_action', callback_id: 'another_message_action_callback_id' },
+            ({ }) => { actionFn(); });
           app.action({ type: 'message_action', callback_id: 'does_not_exist' }, ({ }) => { actionFn(); });
           app.action({ callback_id: 'interactive_message_callback_id' }, ({ }) => { actionFn(); });
           app.action({ callback_id: 'dialog_submission_callback_id' }, ({ }) => { actionFn(); });

--- a/src/ExpressReceiver.spec.ts
+++ b/src/ExpressReceiver.spec.ts
@@ -41,6 +41,17 @@ describe('ExpressReceiver', () => {
     });
   });
 
+  describe('start/stop', () => {
+    it('should be available', async () => {
+      const receiver = new ExpressReceiver({
+        signingSecret: 'my-secret',
+        logger: noopLogger,
+      });
+      await receiver.start(9999);
+      await receiver.stop();
+    });
+  });
+
   describe('built-in middleware', () => {
     describe('ssl_check requset handler', () => {
       it('should handle valid requests', async () => {

--- a/src/ExpressReceiver.ts
+++ b/src/ExpressReceiver.ts
@@ -151,7 +151,7 @@ export default class ExpressReceiver extends EventEmitter implements Receiver {
   }
 }
 
-const respondToSslCheck: RequestHandler = (req, res, next) => {
+export const respondToSslCheck: RequestHandler = (req, res, next) => {
   if (req.body && req.body.ssl_check) {
     res.send();
     return;
@@ -159,7 +159,7 @@ const respondToSslCheck: RequestHandler = (req, res, next) => {
   next();
 };
 
-const respondToUrlVerification: RequestHandler = (req, res, next) => {
+export const respondToUrlVerification: RequestHandler = (req, res, next) => {
   if (req.body && req.body.type && req.body.type === 'url_verification') {
     res.json({ challenge: req.body.challenge });
     return;

--- a/src/conversation-store.spec.ts
+++ b/src/conversation-store.spec.ts
@@ -221,9 +221,12 @@ function createFakeStore(
 ): FakeStore {
   return {
     // NOTE (Nov 2019): We had to convert to 'unknown' first due to the following error:
-    // src/conversation-store.spec.ts:223:10 - error TS2352: Conversion of type 'SinonSpy<any[], any>' to type 'SinonSpy<[string, any, (number | undefined)?], Promise<unknown>>' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
+    // src/conversation-store.spec.ts:223:10 - error TS2352: Conversion of type 'SinonSpy<any[], any>' to
+    // type 'SinonSpy<[string, any, (number | undefined)?], Promise<unknown>>' may be a mistake because neither type
+    // sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
     //   Types of property 'firstCall' are incompatible.
-    //     Type 'SinonSpyCall<any[], any>' is not comparable to type 'SinonSpyCall<[string, any, (number | undefined)?], Promise<unknown>>'.
+    //     Type 'SinonSpyCall<any[], any>' is not comparable to type 'SinonSpyCall<[string, any, (number | undefined)?],
+    // Promise<unknown>>'.
     //       Type 'any[]' is not comparable to type '[string, any, (number | undefined)?]'.
     // 223     set: setSpy as SinonSpy<Parameters<ConversationStore['set']>, ReturnType<ConversationStore['set']>>,
     //              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/middleware/builtin.spec.ts
+++ b/src/middleware/builtin.spec.ts
@@ -5,7 +5,14 @@ import sinon from 'sinon';
 import { ErrorCode } from '../errors';
 import { Override, delay, wrapToResolveOnFirstCall } from '../test-helpers';
 import rewiremock from 'rewiremock';
-import { SlackEventMiddlewareArgs, NextMiddleware, Context, MessageEvent, ContextMissingPropertyError, SlackCommandMiddlewareArgs } from '../types';
+import {
+  SlackEventMiddlewareArgs,
+  NextMiddleware,
+  Context,
+  MessageEvent,
+  ContextMissingPropertyError,
+  SlackCommandMiddlewareArgs,
+} from '../types';
 import { onlyCommands, onlyEvents, matchCommandName, matchEventType, subtype } from './builtin';
 import { SlashCommand } from '../types/command/index';
 import { SlackEvent, AppMentionEvent, BotMessageEvent } from '../types/events/base-events';
@@ -431,12 +438,12 @@ describe('onlyCommands', () => {
     const payload: SlashCommand = { ...validCommandPayload };
     const fakeNext = sinon.fake();
     onlyCommands({
-      payload: payload,
+      payload,
       command: payload,
       body: payload,
-      say: () => { },
-      respond: () => { },
-      ack: () => { },
+      say: () => { /* noop */ },
+      respond: () => { /* noop */ },
+      ack: () => { /* noop */ },
       next: fakeNext,
       context: {},
     });
@@ -447,13 +454,13 @@ describe('onlyCommands', () => {
     const payload: any = {};
     const fakeNext = sinon.fake();
     onlyCommands({
-      payload: payload,
+      payload,
       action: payload,
       command: undefined,
       body: payload,
-      say: () => { },
-      respond: () => { },
-      ack: () => { },
+      say: () => { /* noop */ },
+      respond: () => { /* noop */ },
+      ack: () => { /* noop */ },
       next: fakeNext,
       context: {},
     });
@@ -462,15 +469,15 @@ describe('onlyCommands', () => {
 });
 
 describe('matchCommandName', () => {
-  function buildArgs(fakeNext: NextMiddleware) {
+  function buildArgs(fakeNext: NextMiddleware): SlackCommandMiddlewareArgs & { next: any, context: any } {
     const payload: SlashCommand = { ...validCommandPayload };
     return {
-      payload: payload,
+      payload,
       command: payload,
       body: payload,
-      say: () => { },
-      respond: () => { },
-      ack: () => { },
+      say: () => { /* noop */ },
+      respond: () => { /* noop */ },
+      ack: () => { /* noop */ },
       next: fakeNext,
       context: {},
     };
@@ -505,9 +512,9 @@ describe('onlyEvents', () => {
         type: 'event_callback',
         event_id: 'event-id-value',
         event_time: 123,
-        authed_users: []
+        authed_users: [],
       },
-      say: () => { },
+      say: () => { /* noop */ },
     };
     onlyEvents({ next: fakeNext, context: {}, ...args });
     assert.isTrue(fakeNext.called);
@@ -517,12 +524,12 @@ describe('onlyEvents', () => {
     const payload: SlashCommand = { ...validCommandPayload };
     const fakeNext = sinon.fake();
     onlyEvents({
-      payload: payload,
+      payload,
       command: payload,
       body: payload,
-      say: () => { },
-      respond: () => { },
-      ack: () => { },
+      say: () => { /* noop */ },
+      respond: () => { /* noop */ },
+      ack: () => { /* noop */ },
       next: fakeNext,
       context: {},
     });
@@ -544,9 +551,9 @@ describe('matchEventType', () => {
         type: 'event_callback',
         event_id: 'event-id-value',
         event_time: 123,
-        authed_users: []
+        authed_users: [],
       },
-      say: () => { },
+      say: () => { /* noop */ },
     };
   }
 
@@ -577,9 +584,9 @@ describe('subtype', () => {
         type: 'event_callback',
         event_id: 'event-id-value',
         event_time: 123,
-        authed_users: []
+        authed_users: [],
       },
-      say: () => { },
+      say: () => { /* noop */ },
     };
   }
 
@@ -603,7 +610,8 @@ interface DummyContext {
 }
 
 type MessageMiddlewareArgs = SlackEventMiddlewareArgs<'message'> & { next: NextMiddleware, context: Context };
-type TokensRevokedMiddlewareArgs = SlackEventMiddlewareArgs<'tokens_revoked'> & { next: NextMiddleware, context: Context };
+type TokensRevokedMiddlewareArgs = SlackEventMiddlewareArgs<'tokens_revoked'>
+  & { next: NextMiddleware, context: Context };
 
 type MemberJoinedOrLeftChannelMiddlewareArgs = SlackEventMiddlewareArgs<'member_joined_channel' | 'member_left_channel'>
   & { next: NextMiddleware, context: Context };
@@ -651,7 +659,7 @@ const appMentionEvent: AppMentionEvent = {
   text: 'this is my message',
   ts: '123.123',
   channel: 'C1234567',
-  event_ts: '123.123'
+  event_ts: '123.123',
 };
 
 const botMessageEvent: BotMessageEvent & MessageEvent = {
@@ -661,5 +669,5 @@ const botMessageEvent: BotMessageEvent & MessageEvent = {
   user: 'U1234567',
   ts: '123.123',
   text: 'this is my message',
-  bot_id: 'B1234567'
+  bot_id: 'B1234567',
 };

--- a/src/middleware/builtin.spec.ts
+++ b/src/middleware/builtin.spec.ts
@@ -6,6 +6,9 @@ import { ErrorCode } from '../errors';
 import { Override, delay, wrapToResolveOnFirstCall } from '../test-helpers';
 import rewiremock from 'rewiremock';
 import { SlackEventMiddlewareArgs, NextMiddleware, Context, MessageEvent, ContextMissingPropertyError, SlackCommandMiddlewareArgs } from '../types';
+import { onlyCommands, onlyEvents, matchCommandName, matchEventType, subtype } from './builtin';
+import { SlashCommand } from '../types/command/index';
+import { SlackEvent, AppMentionEvent, BotMessageEvent } from '../types/events/base-events';
 
 describe('matchMessage()', () => {
   function initializeTestCase(pattern: string | RegExp): Mocha.AsyncFunc {
@@ -422,6 +425,177 @@ describe('ignoreSelf()', () => {
   });
 });
 
+describe('onlyCommands', () => {
+
+  it('should detect valid requests', async () => {
+    const payload: SlashCommand = { ...validCommandPayload };
+    const fakeNext = sinon.fake();
+    onlyCommands({
+      payload: payload,
+      command: payload,
+      body: payload,
+      say: () => { },
+      respond: () => { },
+      ack: () => { },
+      next: fakeNext,
+      context: {},
+    });
+    assert.isTrue(fakeNext.called);
+  });
+
+  it('should skip other requests', async () => {
+    const payload: any = {};
+    const fakeNext = sinon.fake();
+    onlyCommands({
+      payload: payload,
+      action: payload,
+      command: undefined,
+      body: payload,
+      say: () => { },
+      respond: () => { },
+      ack: () => { },
+      next: fakeNext,
+      context: {},
+    });
+    assert.isTrue(fakeNext.notCalled);
+  });
+});
+
+describe('matchCommandName', () => {
+  function buildArgs(fakeNext: NextMiddleware) {
+    const payload: SlashCommand = { ...validCommandPayload };
+    return {
+      payload: payload,
+      command: payload,
+      body: payload,
+      say: () => { },
+      respond: () => { },
+      ack: () => { },
+      next: fakeNext,
+      context: {},
+    };
+  }
+
+  it('should detect valid requests', async () => {
+    const fakeNext = sinon.fake();
+    matchCommandName('/hi')(buildArgs(fakeNext));
+    assert.isTrue(fakeNext.called);
+  });
+
+  it('should skip other requests', async () => {
+    const fakeNext = sinon.fake();
+    matchCommandName('/hello')(buildArgs(fakeNext));
+    assert.isTrue(fakeNext.notCalled);
+  });
+});
+
+describe('onlyEvents', () => {
+
+  it('should detect valid requests', async () => {
+    const fakeNext = sinon.fake();
+    const args: SlackEventMiddlewareArgs<'app_mention'> & { event?: SlackEvent } = {
+      payload: appMentionEvent,
+      event: appMentionEvent,
+      message: null as never, // a bit hackey to sartisfy TS compiler
+      body: {
+        token: 'token-value',
+        team_id: 'T1234567',
+        api_app_id: 'A1234567',
+        event: appMentionEvent,
+        type: 'event_callback',
+        event_id: 'event-id-value',
+        event_time: 123,
+        authed_users: []
+      },
+      say: () => { },
+    };
+    onlyEvents({ next: fakeNext, context: {}, ...args });
+    assert.isTrue(fakeNext.called);
+  });
+
+  it('should skip other requests', async () => {
+    const payload: SlashCommand = { ...validCommandPayload };
+    const fakeNext = sinon.fake();
+    onlyEvents({
+      payload: payload,
+      command: payload,
+      body: payload,
+      say: () => { },
+      respond: () => { },
+      ack: () => { },
+      next: fakeNext,
+      context: {},
+    });
+    assert.isFalse(fakeNext.called);
+  });
+});
+
+describe('matchEventType', () => {
+  function buildArgs(): SlackEventMiddlewareArgs<'app_mention'> & { event?: SlackEvent } {
+    return {
+      payload: appMentionEvent,
+      event: appMentionEvent,
+      message: null as never, // a bit hackey to sartisfy TS compiler
+      body: {
+        token: 'token-value',
+        team_id: 'T1234567',
+        api_app_id: 'A1234567',
+        event: appMentionEvent,
+        type: 'event_callback',
+        event_id: 'event-id-value',
+        event_time: 123,
+        authed_users: []
+      },
+      say: () => { },
+    };
+  }
+
+  it('should detect valid requests', async () => {
+    const fakeNext = sinon.fake();
+    matchEventType('app_mention')({ next: fakeNext, context: {}, ...buildArgs() });
+    assert.isTrue(fakeNext.called);
+  });
+
+  it('should skip other requests', async () => {
+    const fakeNext = sinon.fake();
+    matchEventType('app_home_opened')({ next: fakeNext, context: {}, ...buildArgs() });
+    assert.isFalse(fakeNext.called);
+  });
+});
+
+describe('subtype', () => {
+  function buildArgs(): SlackEventMiddlewareArgs<'message'> & { event?: SlackEvent } {
+    return {
+      payload: botMessageEvent,
+      event: botMessageEvent,
+      message: botMessageEvent,
+      body: {
+        token: 'token-value',
+        team_id: 'T1234567',
+        api_app_id: 'A1234567',
+        event: botMessageEvent,
+        type: 'event_callback',
+        event_id: 'event-id-value',
+        event_time: 123,
+        authed_users: []
+      },
+      say: () => { },
+    };
+  }
+
+  it('should detect valid requests', async () => {
+    const fakeNext = sinon.fake();
+    subtype('bot_message')({ next: fakeNext, context: {}, ...buildArgs() });
+    assert.isTrue(fakeNext.called);
+  });
+
+  it('should skip other requests', async () => {
+    const fakeNext = sinon.fake();
+    subtype('me_message')({ next: fakeNext, context: {}, ...buildArgs() });
+    assert.isFalse(fakeNext.called);
+  });
+});
+
 /* Testing Harness */
 
 interface DummyContext {
@@ -456,3 +630,36 @@ function createFakeMessageEvent(content: string | MessageEvent['blocks'] = ''): 
   }
   return event as MessageEvent;
 }
+
+const validCommandPayload: SlashCommand = {
+  token: 'token-value',
+  command: '/hi',
+  text: 'Steve!',
+  response_url: 'https://hooks.slack.com/foo/bar',
+  trigger_id: 'trigger-id-value',
+  user_id: 'U1234567',
+  user_name: 'steve',
+  team_id: 'T1234567',
+  team_domain: 'awesome-eng-team',
+  channel_id: 'C1234567',
+  channel_name: 'random',
+};
+
+const appMentionEvent: AppMentionEvent = {
+  type: 'app_mention',
+  user: 'U1234567',
+  text: 'this is my message',
+  ts: '123.123',
+  channel: 'C1234567',
+  event_ts: '123.123'
+};
+
+const botMessageEvent: BotMessageEvent & MessageEvent = {
+  type: 'message',
+  subtype: 'bot_message',
+  channel: 'C1234567',
+  user: 'U1234567',
+  ts: '123.123',
+  text: 'this is my message',
+  bot_id: 'B1234567'
+};

--- a/src/test-helpers.ts
+++ b/src/test-helpers.ts
@@ -47,7 +47,9 @@ export function createFakeLogger(): FakeLogger {
     // NOTE: the two casts are because of a TypeScript inconsistency with tuple types and any[]. all tuple types
     // should be assignable to any[], but TypeScript doesn't think so.
     // UPDATE (Nov 2019):
-    // src/test-helpers.ts:49:15 - error TS2352: Conversion of type 'SinonSpy<any[], any>' to type 'SinonSpy<[LogLevel], void>' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
+    // src/test-helpers.ts:49:15 - error TS2352: Conversion of type 'SinonSpy<any[], any>' to type 'SinonSpy<[LogLevel],
+    //  void>' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional,
+    // convert the expression to 'unknown' first.
     //   Property '0' is missing in type 'any[]' but required in type '[LogLevel]'.
     // 49     setLevel: sinon.fake() as SinonSpy<Parameters<Logger['setLevel']>, ReturnType<Logger['setLevel']>>,
     //                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
###  Summary

This pull request adds more unit tests for `ExpressReceiver` and built-in middleware. It improves the code coverage by ~5.44%~ 5.8% (from 73.00% to 78.80%).
https://codecov.io/gh/seratch/bolt/tree/702ca613900a36ca09147cf086c67cc58522c4c7

The only changes introduced to the main code is allowing users to access the following functions.

* respondToSslCheck
* respondToUrlVerification

I believe there is no issue with it. But, if there is a plan to change the internals of `ExpressReceiver` a lot, I can put it on hold until then. I myself don't have such plans.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).