### PR TITLE
Fix #168 Give listeners and middleware access to the logger

### DIFF
--- a/src/App.spec.ts
+++ b/src/App.spec.ts
@@ -551,6 +551,56 @@ describe('App', () => {
         });
       });
 
+      describe('logger', () => {
+
+        it('should be available in middleware/listener args', async () => {
+          // Arrange
+          const App = await importApp(overrides); // tslint:disable-line:variable-name
+          const fakeLogger = createFakeLogger();
+          const app = new App({
+            logger: fakeLogger,
+            receiver: fakeReceiver,
+            authorize: sinon.fake.resolves(dummyAuthorizationResult),
+          });
+          app.use(({ logger, body }) => {
+            logger.info(body);
+          });
+
+          app.event('app_home_opened', ({ logger, event }) => {
+            logger.debug(event);
+          });
+
+          const receiverEvents = [
+            {
+              body: {
+                type: 'event_callback',
+                token: 'XXYYZZ',
+                team_id: 'TXXXXXXXX',
+                api_app_id: 'AXXXXXXXXX',
+                event: {
+                  type: 'app_home_opened',
+                  event_ts: '1234567890.123456',
+                  user: 'UXXXXXXX1',
+                  text: 'hello friends!',
+                  tab: 'home',
+                  view: {},
+                },
+              },
+              respond: noop,
+              ack: noop,
+            },
+          ];
+
+          // Act
+          receiverEvents.forEach(event => fakeReceiver.emit('message', event));
+          await delay();
+
+          // Assert
+          assert.isTrue(fakeLogger.info.called);
+          assert.isTrue(fakeLogger.debug.called);
+        });
+      });
+
       describe('say()', () => {
 
         function createChannelContextualReceiverEvents(channelId: string): ReceiverEvent[] {

--- a/src/App.ts
+++ b/src/App.ts
@@ -411,7 +411,7 @@ export default class App {
     // Set body and payload (this value will eventually conform to AnyMiddlewareArgs)
     // NOTE: the following doesn't work because... distributive?
     // const listenerArgs: Partial<AnyMiddlewareArgs> = {
-    const listenerArgs: Pick<AnyMiddlewareArgs, 'body' | 'payload'> & {
+    const listenerArgs: Pick<AnyMiddlewareArgs, 'logger' | 'body' | 'payload'> & {
       /** Say function might be set below */
       say?: SayFn
       /** Respond function might be set below */
@@ -419,6 +419,7 @@ export default class App {
       /** Ack function might be set below */
       ack?: AckFn<any>,
     } = {
+      logger: this.logger,
       body: bodyArg,
       payload:
         (type === IncomingEventType.Event) ?

--- a/src/middleware/builtin.spec.ts
+++ b/src/middleware/builtin.spec.ts
@@ -3,7 +3,7 @@ import 'mocha';
 import { assert } from 'chai';
 import sinon from 'sinon';
 import { ErrorCode } from '../errors';
-import { Override, delay, wrapToResolveOnFirstCall } from '../test-helpers';
+import { Override, delay, wrapToResolveOnFirstCall, createFakeLogger } from '../test-helpers';
 import rewiremock from 'rewiremock';
 import {
   SlackEventMiddlewareArgs,
@@ -433,11 +433,13 @@ describe('ignoreSelf()', () => {
 });
 
 describe('onlyCommands', () => {
+  const logger = createFakeLogger();
 
   it('should detect valid requests', async () => {
     const payload: SlashCommand = { ...validCommandPayload };
     const fakeNext = sinon.fake();
     onlyCommands({
+      logger,
       payload,
       command: payload,
       body: payload,
@@ -454,6 +456,7 @@ describe('onlyCommands', () => {
     const payload: any = {};
     const fakeNext = sinon.fake();
     onlyCommands({
+      logger,
       payload,
       action: payload,
       command: undefined,
@@ -469,9 +472,12 @@ describe('onlyCommands', () => {
 });
 
 describe('matchCommandName', () => {
+  const logger = createFakeLogger();
+
   function buildArgs(fakeNext: NextMiddleware): SlackCommandMiddlewareArgs & { next: any, context: any } {
     const payload: SlashCommand = { ...validCommandPayload };
     return {
+      logger,
       payload,
       command: payload,
       body: payload,
@@ -498,9 +504,12 @@ describe('matchCommandName', () => {
 
 describe('onlyEvents', () => {
 
+  const logger = createFakeLogger();
+
   it('should detect valid requests', async () => {
     const fakeNext = sinon.fake();
     const args: SlackEventMiddlewareArgs<'app_mention'> & { event?: SlackEvent } = {
+      logger,
       payload: appMentionEvent,
       event: appMentionEvent,
       message: null as never, // a bit hackey to sartisfy TS compiler
@@ -524,6 +533,7 @@ describe('onlyEvents', () => {
     const payload: SlashCommand = { ...validCommandPayload };
     const fakeNext = sinon.fake();
     onlyEvents({
+      logger,
       payload,
       command: payload,
       body: payload,
@@ -538,8 +548,11 @@ describe('onlyEvents', () => {
 });
 
 describe('matchEventType', () => {
+  const logger = createFakeLogger();
+
   function buildArgs(): SlackEventMiddlewareArgs<'app_mention'> & { event?: SlackEvent } {
     return {
+      logger,
       payload: appMentionEvent,
       event: appMentionEvent,
       message: null as never, // a bit hackey to sartisfy TS compiler
@@ -571,8 +584,11 @@ describe('matchEventType', () => {
 });
 
 describe('subtype', () => {
+  const logger = createFakeLogger();
+
   function buildArgs(): SlackEventMiddlewareArgs<'message'> & { event?: SlackEvent } {
     return {
+      logger,
       payload: botMessageEvent,
       event: botMessageEvent,
       message: botMessageEvent,

--- a/src/types/actions/index.ts
+++ b/src/types/actions/index.ts
@@ -8,6 +8,7 @@ import { InteractiveMessage } from './interactive-message';
 import { DialogSubmitAction, DialogValidation } from './dialog-action';
 import { MessageAction } from './message-action';
 import { SayFn, SayArguments, RespondFn, AckFn } from '../utilities';
+import { Logger } from '@slack/logger';
 
 /**
  * All known actions from Slack's Block Kit interactive components, message actions, dialogs, and legacy interactive
@@ -34,6 +35,7 @@ export type SlackAction = BlockAction | InteractiveMessage | DialogSubmitAction 
  * this case `ElementAction` must extend `BasicElementAction`.
  */
 export interface SlackActionMiddlewareArgs<Action extends SlackAction = SlackAction> {
+  logger: Logger;
   payload: (
     Action extends BlockAction<infer ElementAction> ? ElementAction :
     Action extends InteractiveMessage<infer InteractiveAction> ? InteractiveAction :

--- a/src/types/command/index.ts
+++ b/src/types/command/index.ts
@@ -1,10 +1,12 @@
 import { StringIndexed } from '../helpers';
 import { SayFn, RespondFn, RespondArguments, AckFn } from '../utilities';
+import { Logger } from '@slack/logger';
 
 /**
  * Arguments which listeners and middleware receive to process a slash command from Slack.
  */
 export interface SlackCommandMiddlewareArgs {
+  logger: Logger;
   payload: SlashCommand;
   command: this['payload'];
   body: this['payload'];

--- a/src/types/events/index.ts
+++ b/src/types/events/index.ts
@@ -2,11 +2,13 @@ export * from './base-events';
 import { SlackEvent, BasicSlackEvent } from './base-events';
 import { StringIndexed } from '../helpers';
 import { SayFn } from '../utilities';
+import { Logger } from '@slack/logger';
 
 /**
  * Arguments which listeners and middleware receive to process an event from Slack's Events API.
  */
 export interface SlackEventMiddlewareArgs<EventType extends string = string> {
+  logger: Logger;
   payload: EventFromType<EventType>;
   event: this['payload'];
   message: EventType extends 'message' ? this['payload'] : never;

--- a/src/types/options/index.ts
+++ b/src/types/options/index.ts
@@ -1,11 +1,13 @@
 import { Option } from '@slack/types';
 import { StringIndexed, XOR } from '../helpers';
 import { AckFn } from '../utilities';
+import { Logger } from '@slack/logger';
 
 /**
  * Arguments which listeners and middleware receive to process an options request from Slack
  */
 export interface SlackOptionsMiddlewareArgs<Source extends OptionsSource = OptionsSource> {
+  logger: Logger;
   payload: OptionsRequest<Source>;
   body: this['payload'];
   options: this['payload'];

--- a/src/types/view/index.ts
+++ b/src/types/view/index.ts
@@ -1,5 +1,6 @@
 import { StringIndexed } from '../helpers';
 import { RespondArguments, AckFn } from '../utilities';
+import { Logger } from '@slack/logger';
 
 /**
  * Known view action types
@@ -10,6 +11,7 @@ export type SlackViewAction = ViewSubmitAction | ViewClosedAction;
  * Arguments which listeners and middleware receive to process a view submission event from Slack.
  */
 export interface SlackViewMiddlewareArgs<ViewActionType extends SlackViewAction = SlackViewAction> {
+  logger: Logger;
   payload: ViewOutput;
   view: this['payload'];
   body: ViewActionType;


### PR DESCRIPTION
###  Summary

This pull request fixes #168. As this PR depends on #357's test improvements, other commits are included. The essential change is: https://github.com/slackapi/bolt/commit/4d77395791b0f11d63975a1a518e94b333784d59

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).