### PR TITLE
Tweak a sentence in Japanese documentation

### DIFF
--- a/docs/_advanced/ja_authorization.md
+++ b/docs/_advanced/ja_authorization.md
@@ -47,7 +47,7 @@ const authorizeFn = async ({ teamId, enterpriseId }) => {
     if ((team.teamId === teamId) && (team.enterpriseId === enterpriseId)) {
       // 一致したワークスペースの認証情報を使用
       return {
-        // かわりに userToken を使用
+        // 代わりに userToken をセットしても OK
         botToken: team.botToken,
         botId: team.botId,
         botUserId: team.botUserId


### PR DESCRIPTION
###  Summary

This pull request improves the quality of Japanese documentation. The current comment seems to be a bit confusing. The new one is much closer to the original sentence: `You could also set userToken instead`.

Just in case, I've assigned @girliemac (another Japanese speaker in the team) as a reviewer but I may self merge after waiting for her response for a while.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).