### PR TITLE
updated release steps in maintainers guide

### DIFF
--- a/.github/maintainers_guide.md
+++ b/.github/maintainers_guide.md
@@ -32,8 +32,8 @@ To build the docs locally, you can run `bundle exec jekyll serve`.
 
 1.  Create the commit for the release:
     *  Bump the version number in adherence to [Semantic Versioning](http://semver.org/) in `package.json`.
-    *  Commit with a message including the new version number. For example `v1.0.8`.
-    *  Tag the commit with the version number. For example `v1.0.8`.
+    *  Commit with a message including the new version number. For example `v1.5.0`.
+    *  Tag the commit with the version number. For example `@slack/bolt@1.5.0`.
 
 2.  Merge into master repository
     *  Create a pull request with the commit that was just made. Be certain to include the tag. For
@@ -44,6 +44,7 @@ To build the docs locally, you can run `bundle exec jekyll serve`.
 3.  Distribute the release
     *  Publish to the package manager. Once you have permission to publish on npm, you can run `npm publish`.
     *  Create a GitHub Release with release notes. Release notes should mention contributors (@-mentions) and issues/PRs (#-mentions) for the release.
+    *  Example release: https://github.com/slackapi/bolt/releases/tag/%40slack%2Fbolt%401.5.0
 
 4.  (Slack Internal) Communicate the release internally. Include a link to the GitHub Release.
 


### PR DESCRIPTION
###  Summary

Small update to the release steps for bolt

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).