### PR TITLE
Fix #377 ExpressReceiver's RespondFn implementation doesn't accept a string

### DIFF
--- a/src/ExpressReceiver.spec.ts
+++ b/src/ExpressReceiver.spec.ts
@@ -14,6 +14,8 @@ import ExpressReceiver, {
   verifySignatureAndParseBody,
 } from './ExpressReceiver';
 
+import { RespondArguments } from './types/utilities';
+
 describe('ExpressReceiver', () => {
 
   const noopLogger: Logger = {
@@ -377,6 +379,20 @@ describe('ExpressReceiver', () => {
       await verifySignatureMismatch(req);
     });
 
+  });
+
+  // Just copied the implementation as the method is private and it's a bit hard to write a unit test
+  describe('RespondFn implementation', () => {
+    it('should work with both a string and a RespondArguments', () => {
+      const respond = (response: string | RespondArguments): void => {
+        const validResponse: RespondArguments =
+          (typeof response === 'string') ? { text: response } : response;
+        assert.equal(validResponse.text, 'hello');
+      };
+      respond('hello');
+      respond({ text: 'hello' });
+      respond({ text: 'hello', blocks: [] });
+    });
   });
 
 });

--- a/src/ExpressReceiver.ts
+++ b/src/ExpressReceiver.ts
@@ -10,6 +10,7 @@ import crypto from 'crypto';
 import tsscmp from 'tsscmp';
 import { ErrorCode, errorWithCode } from './errors';
 import { Logger, ConsoleLogger } from '@slack/logger';
+import { RespondArguments } from './types/utilities';
 
 // TODO: we throw away the key names for endpoints, so maybe we should use this interface. is it better for migrations?
 // if that's the reason, let's document that with a comment.
@@ -101,8 +102,10 @@ export default class ExpressReceiver extends EventEmitter implements Receiver {
     };
 
     if (req.body && req.body.response_url) {
-      event.respond = (response): void => {
-        this.axios.post(req.body.response_url, response)
+      event.respond = (response: string | RespondArguments): void => {
+        const validResponse: RespondArguments =
+          (typeof response === 'string') ? { text: response } : response;
+        this.axios.post(req.body.response_url, validResponse)
           .catch((e) => {
             this.emit('error', e);
           });


### PR DESCRIPTION
###  Summary

This pull request fixes #377 by updating the `response` function generation in `ExpressReceiver`. I wanted to write some tests for it but it's still not so easy to have uni tests for the internals of the `requestHandler` method. So, I just cut and pasted the same logic to a test suite this time.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).