### PR TITLE
Fix #382 Missing invite_requested event type

### DIFF
--- a/src/types/events/base-events.ts
+++ b/src/types/events/base-events.ts
@@ -45,6 +45,7 @@ export type SlackEvent =
   | IMCreatedEvent
   | IMHistoryChangedEvent
   | IMOpenEvent
+  | InviteRequestedEvent
   | LinkSharedEvent
   | MemberJoinedChannelEvent
   | MemberLeftChannelEvent
@@ -415,6 +416,26 @@ export interface IMOpenEvent extends StringIndexed {
   type: 'im_open';
   user: string;
   channel: string;
+}
+
+export interface InviteRequestedEvent extends StringIndexed {
+  type: 'invite_requested';
+  invite_request: {
+    id: string;
+    email: string;
+    date_created: number;
+    requester_ids: string[];
+    channel_ids: string[];
+    invite_type: string;
+    real_name: string;
+    date_expire: number;
+    request_reason: string;
+    team: {
+      id: string;
+      name: string;
+      domain: string;
+    }
+  };
 }
 
 export interface LinkSharedEvent extends StringIndexed {

--- a/src/types/events/base-events.ts
+++ b/src/types/events/base-events.ts
@@ -426,7 +426,7 @@ export interface InviteRequestedEvent extends StringIndexed {
     date_created: number;
     requester_ids: string[];
     channel_ids: string[];
-    invite_type: string;
+    invite_type: 'restricted' | 'ultra_restricted' | 'full_member';
     real_name: string;
     date_expire: number;
     request_reason: string;


### PR DESCRIPTION
###  Summary

This pull request fixes #382 by adding a new event type to base-events.ts
https://api.slack.com/events/invite_requested

@aoberoi @stevengill @shaydewael 
If you're aware of some fields that need to be optional, please point them out. 🙏 

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).