### PR TITLE
Fix #355 - processMiddleware doesn't wait for last global middleware's call to `next()`

### DIFF
--- a/src/App.spec.ts
+++ b/src/App.spec.ts
@@ -566,8 +566,9 @@ describe('App', () => {
             receiver: fakeReceiver,
             authorize: sinon.fake.resolves(dummyAuthorizationResult),
           });
-          app.use(({ logger, body }) => {
+          app.use(({ logger, body, next }) => {
             logger.info(body);
+            next();
           });
 
           app.event('app_home_opened', ({ logger, event }) => {
@@ -631,8 +632,9 @@ describe('App', () => {
               return Promise.resolve({ userToken: token, botId: 'B123' });
             },
           });
-          app.use(async ({ client }) => {
+          app.use(async ({ client, next }) => {
             await client.auth.test();
+            next();
           });
           const clients: WebClient[] = [];
           app.event('app_home_opened', async ({ client }) => {

--- a/src/App.spec.ts
+++ b/src/App.spec.ts
@@ -501,7 +501,10 @@ describe('App', () => {
             authorize: sinon.fake.resolves(dummyAuthorizationResult),
           });
 
-          app.use((_args) => { ackFn(); });
+          app.use((_args) => {
+            ackFn();
+            _args.next();
+          });
           app.action('block_action_id', ({ }) => { actionFn(); });
           app.action({ callback_id: 'message_action_callback_id' }, ({ }) => { actionFn(); });
           app.action(

--- a/src/middleware/process.spec.ts
+++ b/src/middleware/process.spec.ts
@@ -1,0 +1,41 @@
+// tslint:disable:no-implicit-dependencies
+import { assert } from 'chai';
+import { processMiddleware } from './process';
+import { Context } from 'mocha';
+import { AnyMiddlewareArgs, Middleware } from '../types';
+
+describe('processMiddleware()', () => {
+  const middlewareOne: Middleware<AnyMiddlewareArgs> = ({ next, context }) => {
+    const fn = () => {
+      context.one = true;
+      next();
+    };
+    setTimeout(fn, 10);
+  };
+  const middlewareTwo: Middleware<AnyMiddlewareArgs> = ({ next, context }) => {
+    const fn = () => {
+      context.two = true;
+      next();
+    };
+    setTimeout(fn, 10);
+  };
+  it('processes all middleware before processing listener', (done) => {
+    processMiddleware(
+      // @ts-ignore
+      {},
+      [middlewareOne, middlewareTwo],
+      (context: Context) => {
+        // ensure that the last middleware ran to completion (i.e., called `next`) before afterMiddleware is called
+        assert.isTrue(context.one);
+        assert.isTrue(context.two);
+        done()
+      },
+      (error?: Error) => {
+        if (error) {
+          console.error(`after post process: ${error && error.message}`);
+        }
+        assert(false);
+      },
+    );
+  });
+});

--- a/src/middleware/process.spec.ts
+++ b/src/middleware/process.spec.ts
@@ -28,7 +28,7 @@ describe('processMiddleware()', () => {
         // ensure that the last middleware ran to completion (i.e., called `next`) before afterMiddleware is called
         assert.isTrue(context.one);
         assert.isTrue(context.two);
-        done()
+        done();
       },
       (error?: Error) => {
         if (error) {
@@ -36,6 +36,9 @@ describe('processMiddleware()', () => {
         }
         assert(false);
       },
+      {},
+      null,
+      null,
     );
   });
 });

--- a/src/middleware/process.ts
+++ b/src/middleware/process.ts
@@ -29,15 +29,13 @@ export function processMiddleware(
     // Continue processing
     if (thisMiddleware !== undefined && !(errorOrPostProcess instanceof Error)) {
       const isLastMiddleware = middlewareIndex === (middleware.length - 1);
-      const nextWhenNotLast = isLastMiddleware ? noop : next;
 
       // In this condition, errorOrPostProcess will be a postProcess function or undefined
       postProcessFns[middlewareIndex - 1] = errorOrPostProcess === undefined ? noopPostProcess : errorOrPostProcess;
-      thisMiddleware({ context, next: nextWhenNotLast, ...initialArguments });
+      thisMiddleware({ context, next, ...initialArguments });
 
       if (isLastMiddleware) {
         postProcessFns[middlewareIndex] = noopPostProcess;
-        process.nextTick(next);
       }
       return;
     }
@@ -78,5 +76,4 @@ export function processMiddleware(
   firstMiddleware({ context, next, ...initialArguments });
 }
 
-function noop(): void { } // tslint:disable-line:no-empty
 const noopPostProcess: PostProcessFn = (error, done) => { done(error); };


### PR DESCRIPTION
###  Summary

This provides a test case for #355 (see src/middleware/process.spec.ts) as well as a proposed fix.

What I think is happening is that for the last global middleware, `processMiddleware` is passing a noop next function and calling next on the next process tick. This leads to unexpected results when the last (or only) global middleware is async, as is the case if you implement a conversation store as outlined [here](https://slack.dev/bolt/concepts#conversation-store)

I had to update a couple global middleware implementations in App.spec.ts that were relying on this behavior and not calling `next()`.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).