### PR TITLE
Specifies view submission response action types

### DIFF
--- a/src/types/view/index.ts
+++ b/src/types/view/index.ts
@@ -82,8 +82,10 @@ export interface ViewOutput {
   close: PlainTextElementOutput | null;
   submit: PlainTextElementOutput | null;
   state: {
-    [blockId: string]: {
-      [actionId: string]: any; // TODO: a union of all the input elements' output payload
+    values: {
+      [blockId: string]: {
+        [actionId: string]: any; // TODO: a union of all the input elements' output payload
+      };
     };
   };
   hash: string;


### PR DESCRIPTION
###  Summary

When listening to a view submission or view closed (using the `app.view()` method), the `ack()` function was incorrectly typed to accept arguments similar to those for the `respond()` function. This PR fixes that issue by defining types for the various response actions that can be used.

Fixes #305 

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).