### PR TITLE
Fix #405 by providing a better way to configure logger

### DIFF
--- a/src/App.spec.ts
+++ b/src/App.spec.ts
@@ -604,6 +604,56 @@ describe('App', () => {
           assert.isTrue(fakeLogger.info.called);
           assert.isTrue(fakeLogger.debug.called);
         });
+
+        it('should work in the case both logger and logLevel are given', async () => {
+          // Arrange
+          const App = await importApp(overrides); // tslint:disable-line:variable-name
+          const fakeLogger = createFakeLogger();
+          const app = new App({
+            logger: fakeLogger,
+            logLevel: LogLevel.DEBUG,
+            receiver: fakeReceiver,
+            authorize: sinon.fake.resolves(dummyAuthorizationResult),
+          });
+          app.use(({ logger, body, next }) => {
+            logger.info(body);
+            next();
+          });
+
+          app.event('app_home_opened', ({ logger, event }) => {
+            logger.debug(event);
+          });
+
+          const receiverEvents = [
+            {
+              body: {
+                type: 'event_callback',
+                token: 'XXYYZZ',
+                team_id: 'TXXXXXXXX',
+                api_app_id: 'AXXXXXXXXX',
+                event: {
+                  type: 'app_home_opened',
+                  event_ts: '1234567890.123456',
+                  user: 'UXXXXXXX1',
+                  text: 'hello friends!',
+                  tab: 'home',
+                  view: {},
+                },
+              },
+              respond: noop,
+              ack: noop,
+            },
+          ];
+
+          // Act
+          receiverEvents.forEach(event => fakeReceiver.emit('message', event));
+          await delay();
+
+          // Assert
+          assert.isTrue(fakeLogger.info.called);
+          assert.isTrue(fakeLogger.debug.called);
+          assert.isTrue(fakeLogger.setLevel.called);
+        });
       });
 
       describe('client', () => {


### PR DESCRIPTION
###  Summary

This pull request fixes #405 by changing the initialization of the `App` instances a bit. The changes included in this PR are:

* Set the logger name for the default one
* Change the default values for `logger`, `logLevel` arguments of `App` constructor to distinguish they're explicitly specified or not
* Stop sharing a single `logger` with `WebClient` as `WebClient` has its own logger initialization logics - in other words, only the logLevel will be shared between Bolt apps and `WebClient`

### The behavior

The log output with this fix will be more straight-forward.

If a developer goes with the default settings (default `ConsoleLogger` and `LogLevel.INFO`) gives only `logLevel` to the `App` constructor as below,

```js
const { LogLevel } = require("@slack/logger");
const { App } = require("@slack/bolt");
const app = new App({
  logLevel: LogLevel.DEBUG,
  token: process.env.SLACK_BOT_TOKEN,
  signingSecret: process.env.SLACK_SIGNING_SECRET
});
```

The logger shows the following outputs.

```
[DEBUG]  WebClient:0 initialized
[DEBUG]  WebClient:0 apiCall('auth.test') start
[DEBUG]  WebClient:0 will perform http request
⚡️ Bolt app is running!
[DEBUG]  WebClient:0 http response received
[DEBUG]  WebClient:1 initialized
[DEBUG]  bolt-app Conversation context not loaded: Conversation not found
```

If a developer wants to customize the logger name, doing as below works.

```js
const { LogLevel, ConsoleLogger } = require("@slack/logger");
const logger = new ConsoleLogger();
logger.setName('my-bolt-app');
logger.setLevel(LogLevel.DEBUG);

const { App } = require("@slack/bolt");
const app = new App({
  logger: logger,
  token: process.env.SLACK_BOT_TOKEN,
  signingSecret: process.env.SLACK_SIGNING_SECRET
});
```

The output can be like this. The only last line is different from the default logger.

```
[DEBUG]  WebClient:0 initialized
[DEBUG]  WebClient:0 apiCall('auth.test') start
[DEBUG]  WebClient:0 will perform http request
⚡️ Bolt app is running!
[DEBUG]  WebClient:0 http response received
[DEBUG]  WebClient:1 initialized
[DEBUG]  my-bolt-app Conversation context not loaded: Conversation not found
```

If a developer gives both `logger` and `logLevel`, Bolt gives priority to `logLevel` than `logger`'s log level (the log level in `logger` will be overwritten by the `logLevel` while the initialization). This behavior is compatible with the past versions so that I think we should not change it at least this time.

### Next Steps

I'm sure this improvement should be applied to both Bolt v1 and v2. Once other maintainers approve this change, I will make another PR that brings the same change to the v2 branch later on.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).