### PR TITLE
Fix #348 app.view() is not described in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,14 +36,19 @@ event, there's a method to attach a listener function.
 // Listen for an event from the Events API
 app.event(eventType, fn);
 
-// Listen for an action from a block element (buttons, menus, etc), dialog submission, message action, or legacy action
+// Listen for an action from a block element (buttons, menus, etc)
 app.action(actionId, fn);
+// Listen for dialog submission, message action, or legacy action
+app.action({ callback_id: callbackId }, fn);
 
 // Listen for a slash command
 app.command(commandName, fn);
 
 // Listen for options requests (from menus with an external data source)
 app.options(actionId, fn);
+
+// Listen for modal view requests
+app.view(callbackId, fn);
 ```
 
 There's a special method that's provided as a convenience to handle Events API events with the type `message`. Also, you


### PR DESCRIPTION
###  Summary

This pull request fixes #348 by adding the explanation about `app.view` handlers on README.

In addition, I wanted to propose having another example of `app.action` with callback_id patterns. Referring to [this table](https://github.com/slackapi/bolt/issues/265#issuecomment-537449896) may be helpful to understand the whole.

There is one more task related to this.

* [ ] cherry-pick the commit after merging this and make a PR to `@slack/bolt@next` branch

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).