### PR TITLE
[v2] Specifies view submission response action types (#404)

### DIFF
--- a/src/types/view/index.ts
+++ b/src/types/view/index.ts
@@ -1,5 +1,6 @@
 import { StringIndexed } from '../helpers';
-import { RespondArguments, AckFn } from '../utilities';
+import { AckFn } from '../utilities';
+import { View } from '@slack/types';
 
 /**
  * Known view action types
@@ -13,7 +14,7 @@ export interface SlackViewMiddlewareArgs<ViewActionType extends SlackViewAction 
   payload: ViewOutput;
   view: this['payload'];
   body: ViewActionType;
-  ack: AckFn<string | RespondArguments>;
+  ack: ViewAckFn<ViewActionType>;
 }
 
 interface PlainTextElementOutput {
@@ -80,7 +81,13 @@ export interface ViewOutput {
   blocks: StringIndexed; // TODO: should this just be any?
   close: PlainTextElementOutput | null;
   submit: PlainTextElementOutput | null;
-  state: object; // TODO: this should probably be expanded in the future
+  state: {
+    values: {
+      [blockId: string]: {
+        [actionId: string]: any; // TODO: a union of all the input elements' output payload
+      };
+    };
+  };
   hash: string;
   private_metadata: string;
   root_view_id: string | null;
@@ -89,3 +96,37 @@ export interface ViewOutput {
   notify_on_close: boolean;
   external_id?: string;
 }
+
+export interface ViewUpdateResponseAction {
+  response_action: 'update';
+  view: View;
+}
+
+export interface ViewPushResponseAction {
+  response_action: 'push';
+  view: View;
+}
+
+export interface ViewClearResponseAction {
+  response_action: 'clear';
+}
+
+export interface ViewErrorsResponseAction {
+  response_action: 'errors';
+  errors: {
+    [blockId: string]: string;
+  };
+}
+
+export type ViewResponseAction =
+  ViewUpdateResponseAction | ViewPushResponseAction | ViewClearResponseAction | ViewErrorsResponseAction;
+
+/**
+ * Type function which given a view action `VA` returns a corresponding type for the `ack()` function. The function is
+ * used to acknowledge the receipt (and possibly signal failure) of an view submission or closure from a listener or
+ * middleware.
+ */
+type ViewAckFn<VA extends SlackViewAction = SlackViewAction> =
+  VA extends ViewSubmitAction ? AckFn<ViewResponseAction> :
+  // ViewClosedActions can only be acknowledged, there are no arguments
+  AckFn<void>;


### PR DESCRIPTION
###  Summary

This pull request brings the great #404 change by @aoberoi to the `@slack/bolt@next` branch (=v2 trunk branch).

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).