### PR TITLE
Gtime sample code update

### DIFF
--- a/docs/_basic/ja_opening_modals.md
+++ b/docs/_basic/ja_opening_modals.md
@@ -16,7 +16,7 @@ order: 9
 
 ```javascript
 // コマンド起動をリッスン
-app.command('/ticket', ({ ack, payload, context }) => {
+app.command('/ticket', ({ ack, body, context }) => {
   // コマンドのリクエストを確認
   ack();
 
@@ -24,7 +24,7 @@ app.command('/ticket', ({ ack, payload, context }) => {
     const result = app.client.views.open({
       token: context.botToken,
       // 適切な trigger_id を受け取ってから 3 秒以内に渡す
-      trigger_id: payload.trigger_id,
+      trigger_id: body.trigger_id,
       // view の値をペイロードに含む
       view: {
         type: 'modal',

--- a/docs/_basic/opening_modals.md
+++ b/docs/_basic/opening_modals.md
@@ -15,7 +15,7 @@ Read more about modal composition in the <a href="https://api.slack.com/surfaces
 
 ```javascript
 // Listen for a slash command invocation
-app.command('/ticket', ({ ack, payload, context }) => {
+app.command('/ticket', ({ ack, body, context }) => {
   // Acknowledge the command request
   ack();
 
@@ -23,7 +23,7 @@ app.command('/ticket', ({ ack, payload, context }) => {
     const result = app.client.views.open({
       token: context.botToken,
       // Pass a valid trigger_id within 3 seconds of receiving it
-      trigger_id: payload.trigger_id,
+      trigger_id: body.trigger_id,
       // View payload
       view: {
         type: 'modal',


### PR DESCRIPTION
###  Summary
Changing payload to body in EN and JA examples. This will work with both commands and other events so it will be applicable in more cases. It will also cut down on some confusion around trying to look for trigger id in the payload object when dealing with block actions. 