### PR TITLE
Fix #422 invalid fields in MultiUsersSelectAction

### DIFF
--- a/src/types/actions/block-action.ts
+++ b/src/types/actions/block-action.ts
@@ -88,8 +88,8 @@ export interface UsersSelectAction extends BasicElementAction<'users_select'> {
  * An action from a multi select menu with user list
  */
 export interface MultiUsersSelectAction extends BasicElementAction<'multi_users_select'> {
-  selected_user: [string];
-  initial_user?: [string];
+  selected_users: [string];
+  initial_users?: [string];
   placeholder?: PlainTextElement;
   confirm?: Confirmation;
 }


### PR DESCRIPTION
###  Summary

This pull request fixes #422 which is my bad in #344. This is a blocker for TypeScript users and is causing bad developer experiences for Visual Studio Code users.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).