### PR TITLE
[v2] Fix #436 View type missing optional id from response

### DIFF
--- a/src/types/actions/block-action.ts
+++ b/src/types/actions/block-action.ts
@@ -1,5 +1,6 @@
-import { PlainTextElement, Confirmation, Option, View } from '@slack/types';
+import { PlainTextElement, Confirmation, Option } from '@slack/types';
 import { StringIndexed } from '../helpers';
+import { ViewOutput } from '../view';
 
 /**
  * All known actions from in Slack's interactive elements
@@ -225,7 +226,7 @@ export interface BlockAction<ElementAction extends BasicElementAction = BlockEle
     text?: string; // undocumented that this is optional, but how could it exist on block kit based messages?
     [key: string]: any;
   };
-  view?: View;
+  view?: ViewOutput;
   token: string;
   response_url: string;
   trigger_id: string;


### PR DESCRIPTION
###  Summary

This pull request is the v2 branch fix for #436 - cherry-picked from #437 

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).