### PR TITLE
added processBeforeResponse flag to ExpressReceiver for FaaS use case

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -62,6 +62,7 @@ const packageJson = require('../package.json'); // tslint:disable-line:no-requir
 export interface AppOptions {
   signingSecret?: ExpressReceiverOptions['signingSecret'];
   endpoints?: ExpressReceiverOptions['endpoints'];
+  processBeforeResponse?: ExpressReceiverOptions['processBeforeResponse'];
   agent?: Agent;
   clientTls?: Pick<SecureContextOptions, 'pfx' | 'key' | 'passphrase' | 'cert' | 'ca'>;
   convoStore?: ConversationStore | false;
@@ -74,7 +75,6 @@ export interface AppOptions {
   logLevel?: LogLevel;
   ignoreSelf?: boolean;
   clientOptions?: Pick<WebClientOptions, 'slackApiUrl'>;
-  processBeforeResponse?: boolean;
 }
 
 export { LogLevel, Logger } from '@slack/logger';

--- a/src/App.ts
+++ b/src/App.ts
@@ -74,6 +74,7 @@ export interface AppOptions {
   logLevel?: LogLevel;
   ignoreSelf?: boolean;
   clientOptions?: Pick<WebClientOptions, 'slackApiUrl'>;
+  processBeforeResponse?: boolean;
 }
 
 export { LogLevel, Logger } from '@slack/logger';
@@ -184,6 +185,7 @@ export default class App {
     logLevel = undefined,
     ignoreSelf = true,
     clientOptions = undefined,
+    processBeforeResponse = false,
   }: AppOptions = {}) {
 
     if (typeof logger === 'undefined') {
@@ -249,6 +251,7 @@ export default class App {
         this.receiver = new ExpressReceiver({
           signingSecret,
           endpoints,
+          processBeforeResponse,
           logger: this.logger,
         });
       }

--- a/src/ExpressReceiver.spec.ts
+++ b/src/ExpressReceiver.spec.ts
@@ -40,6 +40,7 @@ describe('ExpressReceiver', () => {
         signingSecret: 'my-secret',
         logger: noopLogger,
         endpoints: { events: '/custom-endpoint' },
+        processBeforeResponse: true,
       });
       assert.isNotNull(receiver);
     });
@@ -58,7 +59,7 @@ describe('ExpressReceiver', () => {
   });
 
   describe('built-in middleware', () => {
-    describe('ssl_check requset handler', () => {
+    describe('ssl_check request handler', () => {
       it('should handle valid requests', async () => {
         // Arrange
         // tslint:disable-next-line: no-object-literal-type-assertion

--- a/src/ExpressReceiver.ts
+++ b/src/ExpressReceiver.ts
@@ -17,6 +17,7 @@ export interface ExpressReceiverOptions {
   endpoints?: string | {
     [endpointType: string]: string;
   };
+  processBeforeResponse?: boolean;
 }
 
 /**
@@ -30,11 +31,13 @@ export default class ExpressReceiver implements Receiver {
   private server: Server;
   private bolt: App | undefined;
   private logger: Logger;
+  private processBeforeResponse: boolean;
 
   constructor({
     signingSecret = '',
     logger = new ConsoleLogger(),
     endpoints = { events: '/slack/events' },
+    processBeforeResponse = false,
   }: ExpressReceiverOptions) {
     this.app = express();
     // TODO: what about starting an https server instead of http? what about other options to create the server?
@@ -47,6 +50,7 @@ export default class ExpressReceiver implements Receiver {
       this.requestHandler.bind(this),
     ];
 
+    this.processBeforeResponse = processBeforeResponse;
     this.logger = logger;
     const endpointList: string[] = typeof endpoints === 'string' ? [endpoints] : Object.values(endpoints);
     for (const endpoint of endpointList) {
@@ -64,25 +68,52 @@ export default class ExpressReceiver implements Receiver {
     // tslint:disable-next-line: align
     }, 3001);
 
-    const event: ReceiverEvent = {
-      body: req.body,
-      ack: async (response: any): Promise<void> => {
-        if (isAcknowledged) {
-          throw new ReceiverMultipleAckError();
-        }
-        isAcknowledged = true;
-        if (!response) {
-          res.send('');
-        } else if (typeof response === 'string') {
-          res.send(response);
-        } else {
-          res.json(response);
-        }
-      },
-    };
+    let event: ReceiverEvent;
+    let storedResponse = undefined;
+    if (this.processBeforeResponse) {
+      event = {
+        body: req.body,
+        ack: async (response): Promise<void> => {
+          if (isAcknowledged) {
+            throw new ReceiverMultipleAckError();
+          }
+          isAcknowledged = true;
+          if (!response) {
+            res.send('');
+          } else {
+            storedResponse = response;
+          }
+        },
+      };
+
+    } else {
+      event = {
+        body: req.body,
+        ack: async (response): Promise<void> => {
+          if (isAcknowledged) {
+            throw new ReceiverMultipleAckError();
+          }
+          isAcknowledged = true;
+          if (!response) {
+            res.send('');
+          } else if (typeof response === 'string') {
+            res.send(response);
+          } else {
+            res.json(response);
+          }
+        },
+      };
+    }
 
     try {
       await this.bolt?.processEvent(event);
+      if (storedResponse !== undefined) {
+        if (typeof storedResponse === 'string') {
+          res.send(storedResponse);
+        } else {
+          res.json(storedResponse);
+        }
+      }
     } catch (err) {
       res.send(500);
       throw err;

--- a/src/ExpressReceiver.ts
+++ b/src/ExpressReceiver.ts
@@ -68,32 +68,21 @@ export default class ExpressReceiver implements Receiver {
     // tslint:disable-next-line: align
     }, 3001);
 
-    let event: ReceiverEvent;
     let storedResponse = undefined;
-    if (this.processBeforeResponse) {
-      event = {
-        body: req.body,
-        ack: async (response): Promise<void> => {
-          if (isAcknowledged) {
-            throw new ReceiverMultipleAckError();
-          }
-          isAcknowledged = true;
+    const event: ReceiverEvent = {
+      body: req.body,
+      ack: async (response): Promise<void> => {
+        if (isAcknowledged) {
+          throw new ReceiverMultipleAckError();
+        }
+        isAcknowledged = true;
+        if (this.processBeforeResponse) {
           if (!response) {
-            res.send('');
+            storedResponse = '';
           } else {
             storedResponse = response;
           }
-        },
-      };
-
-    } else {
-      event = {
-        body: req.body,
-        ack: async (response): Promise<void> => {
-          if (isAcknowledged) {
-            throw new ReceiverMultipleAckError();
-          }
-          isAcknowledged = true;
+        } else {
           if (!response) {
             res.send('');
           } else if (typeof response === 'string') {
@@ -101,9 +90,9 @@ export default class ExpressReceiver implements Receiver {
           } else {
             res.json(response);
           }
-        },
-      };
-    }
+        }
+      },
+    };
 
     try {
       await this.bolt?.processEvent(event);


### PR DESCRIPTION


###  Summary

added `processBeforeResponse` flag to `ExpressReceiver` to better support Function as a service use case. 

Todo:
- [ ] add docs
- [ ] add tests

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).