### PR TITLE
Make App.handleError() private (v2)

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -622,7 +622,7 @@ export default class App {
   /**
    * Global error handler. The final destination for all errors (hopefully).
    */
-  public handleError(error: Error): Promise<void> {
+  private handleError(error: Error): Promise<void> {
     return this.errorHandler(asCodedError(error));
   }
 


### PR DESCRIPTION
###  Summary

The `App.handleError()` method used to be used by the `ExpressReceiver` before #439. Receivers no longer need this method because they are strictly downstream of the event handling in an app. Therefore it makes sense to turn this into a private method.

Depends on #440 (integration tests will fail without it)

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).