### PR TITLE
Add Japanese version of v2 migration & TS guide

### DIFF
--- a/docs/_tutorials/ja_migration_v2.md
+++ b/docs/_tutorials/ja_migration_v2.md
@@ -10,6 +10,8 @@ permalink: /ja-jp/tutorial/migration-v2
 
 <div class="section-content">
 このガイドは Bolt 1.x を利用しているアプリを 2.x にアップグレードするための手順について説明します。いくつかの変更が必要とはなりますが、ほとんどのアプリの場合で、おそらく対応に必要な時間は 5 〜 15 分程度です。
+
+*注: もしすぐにアップグレードをしない場合は、[Bolt 1.x に関するサポートスケジュール](#bolt-1x-%E3%81%AE%E3%82%B5%E3%83%9D%E3%83%BC%E3%83%88%E3%82%B9%E3%82%B1%E3%82%B8%E3%83%A5%E3%83%BC%E3%83%AB)をご確認ください*
 </div> 
 
 ---
@@ -87,7 +89,7 @@ app.action({ callback_id: 'message-action-callback' }, ({action, ack, context}) 
 ```javascript
 app.shortcut('message-action-callback', async ({shortcut, ack, context}) => {
   await ack();
-  // Do stuff
+  // ここで処理を行う
 })
 ```
 
@@ -118,3 +120,11 @@ async function noBotMessages({message, next }) {
   }
 }
 ```
+
+### Bolt 1.x のサポートスケジュール
+
+`@slack/bolt@1.x` は **2020 年 6 月 30 日** より非推奨となります。それまでの期間はケースバイケースでバグ修正や新機能のバックポートを対応を継続します。`@slack/bolt@1.x` が非推奨となった後は、End of life（正式サポートの終了日）まで **クリティカルなバグ修正のみ** を実装し、クリティカルではない issue や pull request はクローズします。End of life は **2021 年 4 月 30 日** の予定です。この日からは `@slack/bolt@1.x` の開発は完全に終了となり、残っている open issue や pull request もクローズされます。
+
+### TypeScript の最低必須バージョン
+
+[TypeScript 利用ガイド]({{ site.url | append: site.baseurl }}/ja-jp/tutorial/using-typescript) でも説明していますが、`@slack/bolt@2.x` は TypeScirpt 3.7 以上が必須バージョンです。

--- a/docs/_tutorials/ja_using-typescript.md
+++ b/docs/_tutorials/ja_using-typescript.md
@@ -1,0 +1,18 @@
+---
+title: TypeScript での利用ガイド
+order: 3
+slug: using-typescript
+lang: ja-jp
+layout: tutorial
+permalink: /ja-jp/tutorial/using-typescript
+---
+
+# TypeScript での利用ガイド
+
+このプロジェクトは [TypeScript](https://www.typescriptlang.org/) を利用して開発されているため、多くの API が型に関するメタ情報を持っています🎉 Visual Studio Code や Atom をはじめとする型のメタ情報を読み込んでくれるエディタを利用していたり、あなたも TypeScript を使って開発している場合には、このより優れたドキュメンテーションによって、よりスムーズにコードを書いたり、エラーの早期発見、より楽なリファクタリングなどの恩恵を受けることができるでしょう。
+
+このページでは、TypeScript を利用しているプロジェクトからこの npm パッケージを利用する方法について解説します。
+
+### 最低必須バージョン
+
+`@slack/bolt` の最新のメジャーバージョンは TypeScript 3.7 以上での利用をサポートしています。


### PR DESCRIPTION
###  Summary

This pull request adds Japanese version updates for the v2 migration guide and newly added TypeScript page. The following are the original pages.

* https://github.com/slackapi/bolt/blob/master/docs/_tutorials/migration_v2.md
* https://github.com/slackapi/bolt/blob/master/docs/_tutorials/using-typescript.md 

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).