### PR TITLE
Add type aliases (RadioButton and Checkbox) for convenient.

### DIFF
--- a/src/types/actions/block-action.ts
+++ b/src/types/actions/block-action.ts
@@ -250,3 +250,5 @@ export type BlockChannelsSelectAction = BlockAction<ChannelsSelectAction>;
 export type BlockExternalSelectAction = BlockAction<ExternalSelectAction>;
 export type BlockOverflowAction = BlockAction<OverflowAction>;
 export type BlockDatepickerAction = BlockAction<DatepickerAction>;
+export type BlockRadioButtonsAction = BlockAction<RadioButtonsAction>;
+export type BlockCheckboxesAction = BlockAction<CheckboxesAction>;


### PR DESCRIPTION
###  Summary

The `BlockElementAction` already has two types ( `RadioButtonsAction` and `CheckboxesAction` ) which were added recently. However, we currently need to specify them as a parameterized type for  `BlockAction`, because there are no type aliases for them.

We will be able to use them more convenient, if their type aliases are provided.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).