### PR TITLE
Update broken respond example

### DIFF
--- a/docs/_basic/responding_actions.md
+++ b/docs/_basic/responding_actions.md
@@ -33,7 +33,7 @@ Since `respond()` is a utility for calling the `response_url`, it behaves in the
 // Listens to actions triggered with action_id of “user_select”
 app.action('user_choice', async ({ action, ack, respond }) => {
   await ack();
-  await respond(`You selected <@${action.selected_user}>`);
+  await respond({ text: `You selected <@${action.selected_user}>` });
 });
 ```
 


### PR DESCRIPTION
`respond()` doesn't accept string. This example is broken

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).