### PR TITLE
change deprecated usage of res.send

### DIFF
--- a/src/ExpressReceiver.ts
+++ b/src/ExpressReceiver.ts
@@ -108,7 +108,7 @@ export default class ExpressReceiver implements Receiver {
         this.logger.debug('stored response sent');
       }
     } catch (err) {
-      res.send(500);
+      res.status(500).send();
       throw err;
     }
   }


### PR DESCRIPTION
###  Summary

Small fix to replace deprecated usage of `res.send();` for status codes. 

Currently, a deprecation warning will get propagated down to bolt users if they hit this catch block.
### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).